### PR TITLE
HCPE-920: Upgrade to Go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/hcp-sdk-go
 
-go 1.14
+go 1.16
 
 require (
 	github.com/go-openapi/errors v0.19.6


### PR DESCRIPTION
### :hammer_and_wrench: Description

Bumps Go to v1.16. 📈 