### PR TITLE
add auto_hvn_to_hvn_peering consul parameter

### DIFF
--- a/clients/cloud-consul-service/preview/2021-02-04/models/hashicorp_cloud_consul20210204_cluster_config.go
+++ b/clients/cloud-consul-service/preview/2021-02-04/models/hashicorp_cloud_consul20210204_cluster_config.go
@@ -17,6 +17,12 @@ import (
 // swagger:model hashicorp.cloud.consul_20210204.ClusterConfig
 type HashicorpCloudConsul20210204ClusterConfig struct {
 
+	// auto_hvn_to_hvn_peering is only used together with the field consul_config.primary when
+	// creating secondary clusters in a federation. Enable auto_hvn_to_hvn_peering if the
+	// secondary HVN should be peered automatically to every other cluster's HVN in the federation.
+	// If left disabled, the peering has to be done manually.
+	AutoHvnToHvnPeering bool `json:"auto_hvn_to_hvn_peering,omitempty"`
+
 	// capacity_config contains the configuration for the cluster size settings.
 	CapacityConfig *HashicorpCloudConsul20210204CapacityConfig `json:"capacity_config,omitempty"`
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Adding a new parameter. Belongs to https://github.com/hashicorp/cloud-api/pull/47. Following instructions from https://github.com/hashicorp/hcp-sdk-go/pull/24.

<!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 
version of a service SDK was added, what are the key new features or breaking changes? -->

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/terraform-provider-hcp/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Updated cloud-consul-service/preview/2021-02-04 to include new parameter `auto_hvn_to_hvn_peering`.
```

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [x] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?