### PR TITLE
remove existing service SDK before generating

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -69,6 +69,7 @@ jobs:
           rm -rf $GITHUB_WORKSPACE/hcp-sdk-go/temp
 
       - name: Open PR
+        id: pr
         uses: peter-evans/create-pull-request@v3.10.1
         with:
           token: ${{ secrets.SDK_PIPELINE_TOKEN }}
@@ -84,5 +85,6 @@ jobs:
             - Pulled the latest public service SDK from ${{ github.event.inputs.service }}
           delete-branch: true
 
-      - name: Check outputs
-        run: echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"
+      - name: Verify PR created
+        run:  |
+          echo "Pull Request URL - ${{ steps.pr.outputs.pull-request-url }}" || exit 1

--- a/scripts/gen-go-service-sdk.sh
+++ b/scripts/gen-go-service-sdk.sh
@@ -22,10 +22,6 @@ generate_sdk() {
   stage=$2
   version=$3
 
-  if [ -d "clients/$service/$stage/$version" ]; then \
-    echo "Removing original SDK from clients/$service/$stage/$version" && rm -rf "$SCRIPTS_DIR/../clients/$service/$stage/$version"; \
-  fi
-
   echo -e "Creating target SDK directory: ${BOLD}hcp-sdk-go/clients/$service/$stage/$version${NA}"
   mkdir -p "../../../clients/$service/$stage/$version"
 
@@ -43,6 +39,10 @@ generate_sdk() {
 
 # Beginning of generation script.
 service=$1
+
+if [ -d "clients/$service" ]; then \
+  echo "Removing original SDK from clients/$service" && rm -rf "$SCRIPTS_DIR/../clients/$service"; \
+fi
 
 transformer=../../../cmd/transform-swagger
 shared_specs=../../../temp/cloud-shared
@@ -75,10 +75,12 @@ for d in *; do
       generate_sdk "$service" "$stage" "$version"
     fi
   done
+
+  cd ..
 done
 
 # Navigate back to root.
-cd ../../..
+cd ../..
 
 echo -e "Regenerating shared ${BOLD}external${NA} SDK models"
 swagger generate model \


### PR DESCRIPTION
### :hammer_and_wrench: Description

Follow-up fix to #41. Was seeing issues with no diff and thus no PR when kicking off the publish-sdk workflow. Turns out we needed to clear out the complete service SDK, so we don't leave around a ghost preview SDK when an API version goes to stable.