### PR TITLE
Misc dev productivity chores

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,9 @@
 # The Packer clients are owned by Packer
 /clients/cloud-packer-service/ @hashicorp/cloud-experiences-go @hashicorp/packer-cloud-ui @hashicorp/packer-cloud
 
-# The Resource Manager and Operation clients are owned by Dataplane
-/clients/cloud-resource-manager/ @hashicorp/cloud-experiences-go @hashicorp/cloud-dataplane
-/clients/cloud-operation/ @hashicorp/cloud-experiences-go @hashicorp/cloud-dataplane
+# The Network and Resource Manager clients are owned by Controlplane
+/clients/cloud-resource-manager/ @hashicorp/cloud-experiences-go @hashicorp/cloud-control-plane
+/clients/cloud-operation/ @hashicorp/cloud-experiences-go @hashicorp/cloud-control-plane
+
+# The Operation clients are owned by Dataplane
+/clients/cloud-operation/ @hashicorp/cloud-dataplane @hashicorp/cloud-experiences

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,17 @@
 # These owners will be the default owners for everything in
 # the repo, unless a later match takes precedence
-*       @hashicorp/cloud-experiences-go
+
+* @hashicorp/cloud-experiences-go
+
+# The Consul clients are owned by Consul
+/clients/cloud-consul-service/ @hashicorp/cloud-experiences-go @hashicorp/consul-cloud-ui @hashicorp/consul-cloud
+
+# The Vault clients are owned by Vault
+/clients/cloud-vault-service/ @hashicorp/cloud-experiences-go @hashicorp/vault-cloud-ui @hashicorp/vault-cloud
+
+# The Packer clients are owned by Packer
+/clients/cloud-packer-service/ @hashicorp/cloud-experiences-go @hashicorp/packer-cloud-ui @hashicorp/packer-cloud
+
+# The Resource Manager and Operation clients are owned by Dataplane
+/clients/cloud-resource-manager/ @hashicorp/cloud-experiences-go @hashicorp/cloud-dataplane
+/clients/cloud-operation/ @hashicorp/cloud-experiences-go @hashicorp/cloud-dataplane

--- a/.github/workflows/publish-shared-sdk.yml
+++ b/.github/workflows/publish-shared-sdk.yml
@@ -1,15 +1,10 @@
 ---
-name: publish-sdk
+name: publish-shared-sdk
 
-on: 
-  workflow_dispatch:
-      inputs:
-        service:
-          description: 'The service whose SDK needs to be generated'
-          required: true
+on: workflow_dispatch
 
 jobs:
-  publish-sdk:
+  publish-shared-sdk:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout hcp-sdk-go
@@ -22,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: hashicorp/cloud-api
-          ref: auto-update-service-specs
+          ref: master
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
           path: cloud-api
 
@@ -42,20 +37,15 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y rsync
 
-      - name: Copy latest service specs
-        env: 
-          SERVICE: ${{ github.event.inputs.service }}
+      - name: Copy latest cloud-shared specs
         run: |
-          rsync -a $GITHUB_WORKSPACE/cloud-api/specs/"$SERVICE" $GITHUB_WORKSPACE/hcp-sdk-go/temp
           rsync -a $GITHUB_WORKSPACE/cloud-api/specs/cloud-shared $GITHUB_WORKSPACE/hcp-sdk-go/temp
           rsync -a $GITHUB_WORKSPACE/cloud-api/specs/external $GITHUB_WORKSPACE/hcp-sdk-go/temp
 
-      - name: Generate SDK for service
-        env: 
-          SERVICE: ${{ github.event.inputs.service }}
+      - name: Generate SDK for cloud-shared
         run: |
           cd $GITHUB_WORKSPACE/hcp-sdk-go
-          ./scripts/gen-go-service-sdk.sh $SERVICE
+          ./scripts/gen-go-shared-sdk.sh
           rm -rf $GITHUB_WORKSPACE/hcp-sdk-go/temp
 
       - name: Open PR
@@ -64,15 +54,15 @@ jobs:
         with:
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
           path: hcp-sdk-go
-          branch: auto-update-service-sdk
+          branch: auto-update-shared-sdk
           committer: HashiCorp Cloud Services <59096967+hashicorp-cloud@users.noreply.github.com>
-          commit-message: Update ${{ github.event.inputs.service }} SDK 
-          title: '[auto] Update ${{ github.event.inputs.service }} SDK' 
+          commit-message: Update cloud-shared SDK 
+          title: '[auto] Update cloud-shared SDK' 
           body: |
             This is an auto-generated PR created as part of the public SDK pipeline.
 
             Changes:
-            - Pulled the latest public service SDK from ${{ github.event.inputs.service }}
+            - Pulled the latest public service SDK from cloud-shared
           delete-branch: true
 
       # The Open PR action won't fail if no PR is opened, so this step verifies that a PR was actually created.

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ test-ci: go/lint
 # args passed to sdk/update
 commit=false
 
+# This recipe pulls the latest specs for the given service in cloud-api and re-generates the service's go clients.
 .PHONY: sdk/update # service=cloud-foo-service commit=true/false
 sdk/update:
 	@if [ -z $(GITHUB_TOKEN) ]; then \
@@ -66,4 +67,22 @@ sdk/update:
 
 	@if [ $(commit) = true ]; then \
 		./scripts/open-pr.sh $(service); \
+	fi
+
+# This recipe pulls the specs for the given service from locally cloned cloud-api and re-generates the service's go clients.
+.PHONY: sdk/update-local # service=cloud-foo-service
+sdk/update-local:
+	@if [ -z $(service) ]; then \
+		echo "ERROR: No service argument provided, please provide in the format 'service=...'" >&2; \
+  		exit 1; \
+	fi
+
+	bash ./scripts/pull-specs-local.sh $(service);
+
+	@if [ $(service) = "cloud-shared" ]; then \
+		echo "Generating latest SDK for cloud-shared"; \
+		bash ./scripts/gen-go-shared-sdk.sh $(service); \
+	else \
+		echo "Generating latest SDK for $(service)"; \
+		bash ./scripts/gen-go-service-sdk.sh $(service); \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ sdk/update:
 
 	@if [ $(service) = "cloud-shared" ]; then \
 		echo "Generating latest SDK for cloud-shared"; \
-		bash ./scripts/gen-go-shared-sdk.sh $(service); \
+		bash ./scripts/gen-go-shared-sdk.sh; \
 	else \
 		echo "Generating latest SDK for $(service)"; \
 		bash ./scripts/gen-go-service-sdk.sh $(service); \
@@ -81,7 +81,7 @@ sdk/update-local:
 
 	@if [ $(service) = "cloud-shared" ]; then \
 		echo "Generating latest SDK for cloud-shared"; \
-		bash ./scripts/gen-go-shared-sdk.sh $(service); \
+		bash ./scripts/gen-go-shared-sdk.sh; \
 	else \
 		echo "Generating latest SDK for $(service)"; \
 		bash ./scripts/gen-go-service-sdk.sh $(service); \

--- a/scripts/pull-specs-local.sh
+++ b/scripts/pull-specs-local.sh
@@ -9,6 +9,7 @@ SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")
 service=$1
 
 # Copy the latest service specs into a temporary directory in preparation for SDK generation.
-rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/"$service" "$SCRIPTS_DIR"/../temp
-rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/cloud-shared "$SCRIPTS_DIR"/../temp
-rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/external "$SCRIPTS_DIR"/../temp
+mkdir -p "$SCRIPTS_DIR"/../temp/"$service"
+cp -r "$GOPATH"/src/github.com/hashicorp/cloud-api/specs/"$service" "$SCRIPTS_DIR"/../temp
+cp -r "$GOPATH"/src/github.com/hashicorp/cloud-api/specs/cloud-shared "$SCRIPTS_DIR"/../temp
+cp -r "$GOPATH"/src/github.com/hashicorp/cloud-api/specs/external "$SCRIPTS_DIR"/../temp

--- a/scripts/pull-specs-local.sh
+++ b/scripts/pull-specs-local.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script fetches the latest public API specs for a given HCP service ($1) 
+# from the central spec repo, cloud-api.
+
+SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+service=$1
+
+# Copy the latest service specs into a temporary directory in preparation for SDK generation.
+rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/"$service" "$SCRIPTS_DIR"/../temp
+rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/cloud-shared "$SCRIPTS_DIR"/../temp
+rsync -a "$HOME"/go/src/github.com/hashicorp/cloud-api/specs/external "$SCRIPTS_DIR"/../temp


### PR DESCRIPTION
### :hammer_and_wrench: Description

Takes care of a few internal dev productivity chores:
- adds `make sdk/update-local` for when you want to generate test out generating clients with local changes, rather than pulling from the central spec repo's remote master
- adds codeowners to ensure the correct teams are requested reviews on their clients
- refactors `cloud-shared` updates into their own github action, since they're a special case