### PR TITLE
Fix SDK pipeline PR collisions

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: hashicorp/cloud-api
-          ref: auto-update-service-specs
+          ref: auto-update-${{ github.event.inputs.service }}-specs
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
           path: cloud-api
 
@@ -64,7 +64,7 @@ jobs:
         with:
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
           path: hcp-sdk-go
-          branch: auto-update-service-sdk
+          branch: auto-update-${{ github.event.inputs.service }}-sdk
           committer: HashiCorp Cloud Services <59096967+hashicorp-cloud@users.noreply.github.com>
           commit-message: Update ${{ github.event.inputs.service }} SDK 
           title: '[auto] Update ${{ github.event.inputs.service }} SDK' 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Removes the potential for inter-service PR collisions in the SDK pipeline.

Single branch `auto-update-service-specs` -> service-specific branches `auto-update-${{ github.event.inputs.service }}-specs` 