### PR TITLE
Update changelog and bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.0 (January 25, 2022)
+
+FEATURES:
+* Updated cloud-packer-service/preview/2021-04-30 to add UpdateRegistry ([#63](https://github.com/hashicorp/hcp-sdk-go/pull/63)).
+* Updated cloud-network/preview/2020-09-07 ([#64](https://github.com/hashicorp/hcp-sdk-go/pull/64)).
+
 ## 0.15.0 (January 10, 2022)
 
 FEATURES:

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version refers to the current version of hcp-sdk-go.
-var Version = "0.15.0"
+var Version = "0.16.0"


### PR DESCRIPTION
### :hammer_and_wrench: Description

Bumps cloud-packer-service and cloud-network SDKs.