### PR TITLE
Update changelog and bump version to 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.17.0 (February 4, 2022)
+
+FEATURES:
+* Updated cloud-network/preview/2020-09-07 ([#64](https://github.com/hashicorp/hcp-sdk-go/pull/66)).
+
 ## 0.16.0 (January 25, 2022)
 
 FEATURES:

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version refers to the current version of hcp-sdk-go.
-var Version = "0.16.0"
+var Version = "0.17.0"


### PR DESCRIPTION
### :hammer_and_wrench: Description

Bumps cloud-network SDK.