### PR TITLE
Fix httpclient test to allow passing in a customer client

### DIFF
--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -37,9 +37,9 @@ type Config struct {
 	SourceChannel string `json:"source_channel"`
 
 	// Client allows passing a custom http.Client to be used instead of the
-	// cleanhttp default one for both Auth and API requests. This is mostly useful
+	// cleanhttp default one for both Auth and API requests. This should be used only for testing
 	// in testing to provide the httptest.Server's custom client that will trust
-	// it's TLS cert.
+	// its TLS cert.
 	Client *http.Client
 }
 type roundTripperWithSourceChannel struct {
@@ -141,7 +141,7 @@ func excludesScheme(value interface{}) error {
 	u, _ := value.(string)
 
 	// We expect this to NOT have a scheme which means it's not a valid URL and
-	// url.Parse explicitly doesn't support this in it's docs.
+	// url.Parse explicitly doesn't support this in its docs.
 	if strings.Contains(u, "://") {
 		return fmt.Errorf("%q must not include any scheme", u)
 	}


### PR DESCRIPTION
### :hammer_and_wrench: Description

While trying to work out how to test my code that calls the SDK I came looking for an option to allow it to use non-TLS or trust self-signed TLS so I could use a mock server.

Then I got really confused because the test here already does exactly that already 😕 .

Eventually after some head scratching, I realised the test was not actually work as expected! Because the API call error was not being checked, the http client was failing on TLS validation which mean none of the assertions in the server handler were ever being hit.

The good news is that once I fixed that, they did all pass, so the actual library behaviour has always worked, just the test didn't exercise what it seemed to!

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [x] Test fixed
- [x] It's now possible to pass in the `httptest.Server.Client()` which will validate the server TLS certificate and allows testing SDK-dependent code against a simple mock of the API.code . 