### PR TITLE
Allow pipeline to automatically create pull requests with Github CLI 

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -83,9 +83,3 @@ jobs:
           PR_SOURCE: "${{ env.SERVICE_BRANCH }}"
           PR_TARGET: "main"
           GITHUB_TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }} 
-
-      # The Open PR action won't fail if no PR is opened, so this step verifies that a PR was actually created.
-      - name: Verify PR created
-        run:  |
-          pr="${{ steps.pr.outputs.pull-request-url }}"
-          [[ ! -z "$pr" ]] && echo "Pull Request URL - $pr" || exit 1


### PR DESCRIPTION
🛠️ Description
These changes in the publish-api yaml file limit the pipeline's dispatch workflow to use exclusively the Github cli for autogenerating pull requests instead of a 3rd party action. This change minimizes platform exposure upon a 3rd party action's deprecation or improper maintenance.

📒 Additional Notes
This update is being executed in all services with write permissions for creating PRs. The three repos inclusive of these privileges are cloud-api, cloud-ui, and hcp-sdk-go as reflected in the PRs linked below.

❓ Why of the Changes
The security team has decided the platform should prioritize trust of actions that Github maintains. In order of preference, Hashicorp developed scripts or actions, followed by Github maintained, and trailed lastly by third party actions preserve best the platform's security. This allows to best maintain platform dependencies and ensure they're validated at all times.

🔗 External Links
Jira ticket detailing change to Github-supported actions: [TCE-2019](https://hashicorp.atlassian.net/browse/TCE-2019).

Cloud-ui PR: https://github.com/hashicorp/cloud-api/pull/152

Cloud-api PR: https://github.com/hashicorp/cloud-api/pull/152