### PR TITLE
Common HCP Config Interface

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,131 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// The following variables contain the names of environment variables that can
+// be set to provide configuration values.
+const (
+	envVarAuthURL = "HCP_AUTH_URL"
+
+	envVarClientID     = "HCP_CLIENT_ID"
+	envVarClientSecret = "HCP_CLIENT_SECRET"
+
+	envVarPortalURL = "HCP_PORTAL_URL"
+
+	envVarAPIAddress = "HCP_API_ADDRESS"
+
+	// envVarAPIHostnameLegacy is necessary as `HCP_API_HOST` has been used in
+	// the past and needs to be supported for backward compatibility.
+	envVarAPIHostnameLegacy = "HCP_API_HOST"
+
+	envVarAPITLS = "HCP_API_TLS"
+
+	envVarSCADAAddress = "HCP_SCADA_ADDRESS"
+
+	envVarSCADATLS = "HCP_SCADA_TLS"
+)
+
+const (
+	// tlsSettingInsecure is the value TLS environment variables can be set to
+	// if the verification of the server certificate should be skipped.
+	//
+	// This should only be needed for development purposes.
+	tlsSettingInsecure = "insecure"
+
+	// tlsSettingPlain is the value TLS environment variables can be set to if
+	// the communication should happen in plain-text and TLS should be disabled.
+	//
+	// This should only be needed for development purposes.
+	tlsSettingPlain = "plain"
+)
+
+// FromEnv will return a HCPConfigOption that will populate the configuration
+// with values from the environment.
+//
+// It will not fail if no or only part of the variables are present.
+func FromEnv() HCPConfigOption {
+	return func(config *hcpConfig) error {
+		// Read client credentials from the environment, the values will only be
+		// used if both are provided.
+		clientID, clientIDOK := os.LookupEnv(envVarClientID)
+		clientSecret, clientSecretOK := os.LookupEnv(envVarClientSecret)
+
+		if clientIDOK && clientSecretOK {
+			if err := apply(config, WithClientCredentials(clientID, clientSecret)); err != nil {
+				return fmt.Errorf("failed to set client credentials from environment variables (%s, %s): %w", envVarClientID, envVarClientSecret, err)
+			}
+		}
+
+		// Read auth URL from environment
+		if authURL, ok := os.LookupEnv(envVarAuthURL); ok {
+			if err := apply(config, WithAuth(authURL, nil)); err != nil {
+				return fmt.Errorf("failed to parse environment variable %s: %w", envVarPortalURL, err)
+			}
+		}
+
+		// Read portal URL from environment
+		if portalURL, ok := os.LookupEnv(envVarPortalURL); ok {
+			if err := apply(config, WithPortalURL(portalURL)); err != nil {
+				return fmt.Errorf("failed to parse environment variable %s: %w", envVarPortalURL, err)
+			}
+		}
+
+		// Read API address from environment
+		if apiAddress, ok := os.LookupEnv(envVarAPIAddress); ok {
+			config.apiAddress = apiAddress
+		}
+
+		// Read legacy API hostname from environment
+		if legacyAPIHostname, ok := os.LookupEnv(envVarAPIHostnameLegacy); ok {
+			// Allow https:// prefix even though it's the only scheme we allow
+			// as it's more natural to support the URL. Any other scheme we
+			// don't strip which will fail validation.
+			if strings.HasPrefix(strings.ToLower(legacyAPIHostname), "https://") {
+				legacyAPIHostname = legacyAPIHostname[8:]
+			}
+
+			config.apiAddress = legacyAPIHostname
+		}
+
+		// Read API TLS setting from environment
+		if apiTLSSetting, ok := os.LookupEnv(envVarAPITLS); ok {
+			apiTLSConfig, err := tlsConfigForSetting(apiTLSSetting)
+			if err != nil {
+				return fmt.Errorf("failed to configure TLS basd on environment variable %s: %w", envVarAPITLS, err)
+			}
+			config.apiTLSConfig = apiTLSConfig
+		}
+
+		// Read SCADA address from environment
+		if scadaAddress, ok := os.LookupEnv(envVarSCADAAddress); ok {
+			config.scadaAddress = scadaAddress
+		}
+
+		// Read SCADA TLS setting from environment
+		if scadaTLSSetting, ok := os.LookupEnv(envVarSCADATLS); ok {
+			scadaTLSConfig, err := tlsConfigForSetting(scadaTLSSetting)
+			if err != nil {
+				return fmt.Errorf("failed to configure TLS basd on environment variable %s: %w", envVarSCADATLS, err)
+			}
+			config.scadaTLSConfig = scadaTLSConfig
+		}
+
+		return nil
+	}
+}
+
+func tlsConfigForSetting(setting string) (*tls.Config, error) {
+	switch setting {
+	case tlsSettingPlain:
+		return nil, nil
+	case tlsSettingInsecure:
+		return &tls.Config{InsecureSkipVerify: true}, nil
+	default:
+		return nil, fmt.Errorf("invalid TLS setting value: %q", setting)
+	}
+}

--- a/config/env.go
+++ b/config/env.go
@@ -37,11 +37,12 @@ const (
 	// This should only be needed for development purposes.
 	tlsSettingInsecure = "insecure"
 
-	// tlsSettingPlain is the value TLS environment variables can be set to if
-	// the communication should happen in plain-text and TLS should be disabled.
+	// tlsSettingDisabled is the value TLS environment variables can be set to
+	// if the communication should happen in plain-text and TLS should be
+	// disabled.
 	//
 	// This should only be needed for development purposes.
-	tlsSettingPlain = "plain"
+	tlsSettingDisabled = "disabled"
 )
 
 // FromEnv will return a HCPConfigOption that will populate the configuration
@@ -121,7 +122,7 @@ func FromEnv() HCPConfigOption {
 
 func tlsConfigForSetting(setting string) (*tls.Config, error) {
 	switch setting {
-	case tlsSettingPlain:
+	case tlsSettingDisabled:
 		return nil, nil
 	case tlsSettingInsecure:
 		return &tls.Config{InsecureSkipVerify: true}, nil

--- a/config/env.go
+++ b/config/env.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 )
 
-// The following variables contain the names of environment variables that can
+// The following constants contain the names of environment variables that can
 // be set to provide configuration values.
 const (
 	envVarAuthURL = "HCP_AUTH_URL"

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -12,7 +12,8 @@ func TestFromEnv_NoVars(t *testing.T) {
 	require := requirepkg.New(t)
 
 	// Clear the environment
-	os.Clearenv()
+	clearEnv()
+	defer clearEnv()
 
 	// Exercise
 	config := &hcpConfig{}
@@ -25,8 +26,11 @@ func TestFromEnv_NoVars(t *testing.T) {
 func TestFromEnv_SimpleValues(t *testing.T) {
 	require := requirepkg.New(t)
 
+	// Clear the environment
+	clearEnv()
+	defer clearEnv()
+
 	// Prepare the environment
-	os.Clearenv()
 	require.NoError(os.Setenv(envVarAuthURL, "https://my-auth:1234"))
 
 	require.NoError(os.Setenv(envVarClientID, "my-client-id"))
@@ -63,8 +67,11 @@ func TestFromEnv_SimpleValues(t *testing.T) {
 func TestFromEnv_LegacyHostname(t *testing.T) {
 	require := requirepkg.New(t)
 
+	// Clear the environment
+	clearEnv()
+	defer clearEnv()
+
 	// Prepare the environment
-	os.Clearenv()
 	require.NoError(os.Setenv(envVarAPIHostnameLegacy, "https://my-legacy-api"))
 
 	// Exercise
@@ -78,8 +85,11 @@ func TestFromEnv_LegacyHostname(t *testing.T) {
 func TestFromEnv_TLSConfig_Plain(t *testing.T) {
 	require := requirepkg.New(t)
 
+	// Clear the environment
+	clearEnv()
+	defer clearEnv()
+
 	// Prepare the environment
-	os.Clearenv()
 	require.NoError(os.Setenv(envVarAPITLS, tlsSettingDisabled))
 	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingDisabled))
 
@@ -98,8 +108,11 @@ func TestFromEnv_TLSConfig_Plain(t *testing.T) {
 func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
 	require := requirepkg.New(t)
 
+	// Clear the environment
+	clearEnv()
+	defer clearEnv()
+
 	// Prepare the environment
-	os.Clearenv()
 	require.NoError(os.Setenv(envVarAPITLS, tlsSettingInsecure))
 	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingInsecure))
 
@@ -110,4 +123,17 @@ func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
 	// Ensure the TLS configuration is set to insecure
 	require.True(config.apiTLSConfig.InsecureSkipVerify)
 	require.True(config.scadaTLSConfig.InsecureSkipVerify)
+}
+
+// clearEnv will unset any environment variables that FromEnv might read.
+func clearEnv() {
+	os.Unsetenv(envVarAuthURL)
+	os.Unsetenv(envVarClientID)
+	os.Unsetenv(envVarClientSecret)
+	os.Unsetenv(envVarPortalURL)
+	os.Unsetenv(envVarAPIAddress)
+	os.Unsetenv(envVarAPIHostnameLegacy)
+	os.Unsetenv(envVarAPITLS)
+	os.Unsetenv(envVarSCADAAddress)
+	os.Unsetenv(envVarSCADATLS)
 }

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -80,8 +80,8 @@ func TestFromEnv_TLSConfig_Plain(t *testing.T) {
 
 	// Prepare the environment
 	os.Clearenv()
-	require.NoError(os.Setenv(envVarAPITLS, tlsSettingPlain))
-	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingPlain))
+	require.NoError(os.Setenv(envVarAPITLS, tlsSettingDisabled))
+	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingDisabled))
 
 	// Exercise
 	config := &hcpConfig{

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"crypto/tls"
+	"os"
+	"testing"
+
+	requirepkg "github.com/stretchr/testify/require"
+)
+
+func TestFromEnv_NoVars(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Clear the environment
+	os.Clearenv()
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, FromEnv()))
+
+	// Ensure the config has not been modified
+	require.Empty(config)
+}
+
+func TestFromEnv_SimpleValues(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Prepare the environment
+	os.Clearenv()
+	require.NoError(os.Setenv(envVarAuthURL, "https://my-auth:1234"))
+
+	require.NoError(os.Setenv(envVarClientID, "my-client-id"))
+	require.NoError(os.Setenv(envVarClientSecret, "my-client-secret"))
+
+	require.NoError(os.Setenv(envVarPortalURL, "http://my-portal:2345"))
+
+	require.NoError(os.Setenv(envVarAPIAddress, "my-api:3456"))
+	require.NoError(os.Setenv(envVarSCADAAddress, "my-scada:4567"))
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, FromEnv()))
+
+	// Ensure the auth URL is set correctly
+	require.Equal("https", config.authURL.Scheme)
+	require.Equal("my-auth:1234", config.authURL.Host)
+
+	// Ensure the client credentials are set correctly
+	require.Equal("my-client-id", config.clientCredentialsConfig.ClientID)
+	require.Equal("my-client-secret", config.clientCredentialsConfig.ClientSecret)
+
+	// Ensure the portal URL is set correctly
+	require.Equal("http", config.portalURL.Scheme)
+	require.Equal("my-portal:2345", config.portalURL.Host)
+
+	// Ensure the API address is set correctly
+	require.Equal("my-api:3456", config.apiAddress)
+
+	// Ensure the SCADA address is set correctly
+	require.Equal("my-scada:4567", config.scadaAddress)
+}
+
+func TestFromEnv_LegacyHostname(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Prepare the environment
+	os.Clearenv()
+	require.NoError(os.Setenv(envVarAPIHostnameLegacy, "https://my-legacy-api"))
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, FromEnv()))
+
+	// Ensure the API address is set correctly
+	require.Equal("my-legacy-api", config.apiAddress)
+}
+
+func TestFromEnv_TLSConfig_Plain(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Prepare the environment
+	os.Clearenv()
+	require.NoError(os.Setenv(envVarAPITLS, tlsSettingPlain))
+	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingPlain))
+
+	// Exercise
+	config := &hcpConfig{
+		apiTLSConfig:   &tls.Config{},
+		scadaTLSConfig: &tls.Config{},
+	}
+	require.NoError(apply(config, FromEnv()))
+
+	// Ensure the TLS configuration has been reset
+	require.Nil(config.apiTLSConfig)
+	require.Nil(config.scadaTLSConfig)
+}
+
+func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Prepare the environment
+	os.Clearenv()
+	require.NoError(os.Setenv(envVarAPITLS, tlsSettingInsecure))
+	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingInsecure))
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, FromEnv()))
+
+	// Ensure the TLS configuration is set to insecure
+	require.True(config.apiTLSConfig.InsecureSkipVerify)
+	require.True(config.scadaTLSConfig.InsecureSkipVerify)
+}

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -93,7 +93,7 @@ func (c hcpConfig) GetAPIAddress() string {
 }
 
 func (c hcpConfig) GetAPITLSConfig() *tls.Config {
-	return c.apiTLSConfig.Clone()
+	return cloneTLSConfig(c.apiTLSConfig)
 }
 
 func (c hcpConfig) GetSCADAAddress() string {
@@ -101,7 +101,7 @@ func (c hcpConfig) GetSCADAAddress() string {
 }
 
 func (c hcpConfig) GetSCADATLSConfig() *tls.Config {
-	return c.scadaTLSConfig.Clone()
+	return cloneTLSConfig(c.scadaTLSConfig)
 }
 
 func (c hcpConfig) validate() error {

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -14,35 +14,35 @@ type HCPConfig interface {
 	// TokenSource will return a token that can be used to authenticate to HCP.
 	oauth2.TokenSource
 
-	// GetPortalURL will return the URL of the portal.
+	// PortalURL will return the URL of the portal.
 	//
 	// The default portal URL will be the production portal, but the value may
 	// be overwritten for development purposes.
-	GetPortalURL() *url.URL
+	PortalURL() *url.URL
 
-	// GetAPIAddress will return the HCP API address (<hostname>[:port]).
+	// APIAddress will return the HCP API address (<hostname>[:port]).
 	//
 	// The default address will be the HCP production API, but it may be
 	// overwritten for development purposes.
-	GetAPIAddress() string
+	APIAddress() string
 
-	// GetAPITLSConfig will return the API TLS configuration.
+	// APITLSConfig will return the API TLS configuration.
 	//
 	// TLS will be enabled by default but may be disabled for development
 	// purposes.
-	GetAPITLSConfig() *tls.Config
+	APITLSConfig() *tls.Config
 
-	// GetSCADAAddress will return the SCADA address (<hostname>[:port]).
+	// SCADAAddress will return the SCADA address (<hostname>[:port]).
 	//
 	// The default address will be the HCP production SCADA endpoint, but it may
 	// be overwritten for development purposes.
-	GetSCADAAddress() string
+	SCADAAddress() string
 
-	// GetSCADATLSConfig will return the SCADA TLS configuration.
+	// SCADATLSConfig will return the SCADA TLS configuration.
 	//
 	// TLS will be enabled by default but may be disabled for development
 	// purposes.
-	GetSCADATLSConfig() *tls.Config
+	SCADATLSConfig() *tls.Config
 }
 
 type hcpConfig struct {
@@ -81,26 +81,26 @@ func (c *hcpConfig) Token() (*oauth2.Token, error) {
 	return c.tokenSource.Token()
 }
 
-func (c *hcpConfig) GetPortalURL() *url.URL {
+func (c *hcpConfig) PortalURL() *url.URL {
 	// Copy the value in order to not return a pointer to the internal one.
 	portalURL := *c.portalURL
 
 	return &portalURL
 }
 
-func (c *hcpConfig) GetAPIAddress() string {
+func (c *hcpConfig) APIAddress() string {
 	return c.apiAddress
 }
 
-func (c *hcpConfig) GetAPITLSConfig() *tls.Config {
+func (c *hcpConfig) APITLSConfig() *tls.Config {
 	return cloneTLSConfig(c.apiTLSConfig)
 }
 
-func (c *hcpConfig) GetSCADAAddress() string {
+func (c *hcpConfig) SCADAAddress() string {
 	return c.scadaAddress
 }
 
-func (c *hcpConfig) GetSCADATLSConfig() *tls.Config {
+func (c *hcpConfig) SCADATLSConfig() *tls.Config {
 	return cloneTLSConfig(c.scadaTLSConfig)
 }
 

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -1,0 +1,140 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/url"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+// HCPConfig provides configuration values that are useful to interact with HCP.
+type HCPConfig interface {
+	// TokenSource will return a token that can be used to authenticate to HCP.
+	oauth2.TokenSource
+
+	// GetPortalURL will return the URL of the portal.
+	//
+	// The default portal URL will be the production portal, but the value may
+	// be overwritten for development purposes.
+	GetPortalURL() *url.URL
+
+	// GetAPIAddress will return the HCP API address (<hostname>[:port]).
+	//
+	// The default address will be the HCP production API, but it may be
+	// overwritten for development purposes.
+	GetAPIAddress() string
+
+	// GetAPITLSConfig will return the API TLS configuration.
+	//
+	// TLS will be enabled by default but may be disabled for development
+	// purposes.
+	GetAPITLSConfig() *tls.Config
+
+	// GetSCADAAddress will return the SCADA address (<hostname>[:port]).
+	//
+	// The default address will be the HCP production SCADA endpoint, but it may
+	// be overwritten for development purposes.
+	GetSCADAAddress() string
+
+	// GetSCADATLSConfig will return the SCADA TLS configuration.
+	//
+	// TLS will be enabled by default but may be disabled for development
+	// purposes.
+	GetSCADATLSConfig() *tls.Config
+}
+
+type hcpConfig struct {
+	// clientCredentialsConfig is the configuration that will be used to create
+	// the token source.
+	clientCredentialsConfig clientcredentials.Config
+
+	// authURL is the URL that will be used to authenticate.
+	authURL *url.URL
+	// authTLSConfig is the TLS configuration for the auth endpoint. TLS can not
+	// be disabled for the auth endpoint, but the configuration can be set to a
+	// custom one for tests or development.
+	authTLSConfig *tls.Config
+
+	// tokenSource is a self-refreshing token source that returns an access
+	// token that can be used to authenticate against the HCP APIs.
+	tokenSource oauth2.TokenSource
+
+	// portalURL is the base URL of the portal.
+	portalURL *url.URL
+
+	// apiAddress is the address (<hostname>[:port]) of the HCP API.
+	apiAddress string
+	// apiTLSConfig is the TLS configuration for the HCP API. It can be set to
+	// nil if TLS should be disabled.
+	apiTLSConfig *tls.Config
+
+	// scadaAddress is the address (<hostname>[:port]) of the SCADA endpoint.
+	scadaAddress string
+	// scadaTLSConfig is the TLS configuration for the SCADA endpoint. It can be
+	// set to nil if TLS should be disabled.
+	scadaTLSConfig *tls.Config
+}
+
+func (c hcpConfig) Token() (*oauth2.Token, error) {
+	return c.tokenSource.Token()
+}
+
+func (c hcpConfig) GetPortalURL() *url.URL {
+	// Copy the value in order to not return a pointer to the internal one.
+	portalURL := *c.portalURL
+
+	return &portalURL
+}
+
+func (c hcpConfig) GetAPIAddress() string {
+	return c.apiAddress
+}
+
+func (c hcpConfig) GetAPITLSConfig() *tls.Config {
+	return c.apiTLSConfig.Clone()
+}
+
+func (c hcpConfig) GetSCADAAddress() string {
+	return c.scadaAddress
+}
+
+func (c hcpConfig) GetSCADATLSConfig() *tls.Config {
+	return c.scadaTLSConfig.Clone()
+}
+
+func (c hcpConfig) validate() error {
+	// Ensure client credentials have been provided
+	if c.clientCredentialsConfig.ClientID == "" && c.clientCredentialsConfig.ClientSecret == "" {
+		return fmt.Errorf("client credentials need to be provided")
+	}
+
+	// Ensure the auth URL is valid
+	if c.authURL.Host == "" {
+		return fmt.Errorf("the auth URL has to be non-empty")
+	}
+
+	if c.authURL.Scheme != "https" {
+		return fmt.Errorf("the auth URL has to use https at its scheme")
+	}
+
+	// Ensure the portal URL is valid
+	if c.portalURL.Host == "" {
+		return fmt.Errorf("the portal URL has to be non-empty")
+	}
+
+	// Ensure an API address is valid
+	if c.apiAddress == "" {
+		return fmt.Errorf("the API address has to be non-empty")
+	}
+
+	// Ensure an SCADA address is valid
+	if c.scadaAddress == "" {
+		return fmt.Errorf("the SCADA address has to be non-empty")
+	}
+
+	return nil
+}
+
+var _ HCPConfig = hcpConfig{}

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -77,34 +77,34 @@ type hcpConfig struct {
 	scadaTLSConfig *tls.Config
 }
 
-func (c hcpConfig) Token() (*oauth2.Token, error) {
+func (c *hcpConfig) Token() (*oauth2.Token, error) {
 	return c.tokenSource.Token()
 }
 
-func (c hcpConfig) GetPortalURL() *url.URL {
+func (c *hcpConfig) GetPortalURL() *url.URL {
 	// Copy the value in order to not return a pointer to the internal one.
 	portalURL := *c.portalURL
 
 	return &portalURL
 }
 
-func (c hcpConfig) GetAPIAddress() string {
+func (c *hcpConfig) GetAPIAddress() string {
 	return c.apiAddress
 }
 
-func (c hcpConfig) GetAPITLSConfig() *tls.Config {
+func (c *hcpConfig) GetAPITLSConfig() *tls.Config {
 	return cloneTLSConfig(c.apiTLSConfig)
 }
 
-func (c hcpConfig) GetSCADAAddress() string {
+func (c *hcpConfig) GetSCADAAddress() string {
 	return c.scadaAddress
 }
 
-func (c hcpConfig) GetSCADATLSConfig() *tls.Config {
+func (c *hcpConfig) GetSCADATLSConfig() *tls.Config {
 	return cloneTLSConfig(c.scadaTLSConfig)
 }
 
-func (c hcpConfig) validate() error {
+func (c *hcpConfig) validate() error {
 	// Ensure client credentials have been provided
 	if c.clientCredentialsConfig.ClientID == "" && c.clientCredentialsConfig.ClientSecret == "" {
 		return fmt.Errorf("client credentials need to be provided")
@@ -137,4 +137,4 @@ func (c hcpConfig) validate() error {
 	return nil
 }
 
-var _ HCPConfig = hcpConfig{}
+var _ HCPConfig = &hcpConfig{}

--- a/config/new.go
+++ b/config/new.go
@@ -1,0 +1,102 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/clientcredentials"
+)
+
+const (
+	// defaultAuthURL is the URL of the production auth endpoint.
+	defaultAuthURL = "https://auth.hashicorp.com"
+
+	// defaultPortalURL is the URL of the production portal.
+	defaultPortalURL = "https://portal.cloud.hashicorp.com"
+
+	// defaultAPIAddress is the address of the production API.
+	defaultAPIAddress = "api.cloud.hashicorp.com:443"
+
+	// defaultSCADAAddress is the address of the production SCADA endpoint.
+	defaultSCADAAddress = "scada.internal.hashicorp.cloud:7224"
+
+	// The audience is the API identifier configured in the auth provider and
+	// must be provided when requesting an access token for the API. The value
+	// is the same regardless of environment.
+	aud = "https://api.hashicorp.cloud"
+
+	// tokenPath is the path used to retrieve the access token.
+	tokenPath string = "/oauth/token"
+)
+
+// NewHCPConfig will return a HCPConfig. The configuration will be constructed
+// from default values and the passed options.
+//
+// Based on the provided options the configuration values can be provided
+// directly or will be read from other places (e.g. the environment).
+//
+// The configuration will default to values for the HCP production environment,
+// but can be overwritten for development purposes.
+//
+// In addition to the default values the configuration requires client
+// credentials to be provided through one of the passed options (e.g. by using
+// WithCredentials or by using FromEnv and providing the client credentials via
+// environment variables).
+func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
+	// Parse default URLs
+	authURL, _ := url.Parse(defaultAuthURL)
+	portalURL, _ := url.Parse(defaultPortalURL)
+
+	// Prepare basic config with default values.
+	config := &hcpConfig{
+		clientCredentialsConfig: clientcredentials.Config{
+			EndpointParams: url.Values{"audience": {aud}},
+		},
+
+		authURL:       authURL,
+		authTLSConfig: &tls.Config{},
+
+		portalURL: portalURL,
+
+		apiAddress:   defaultAPIAddress,
+		apiTLSConfig: &tls.Config{},
+
+		scadaAddress:   defaultSCADAAddress,
+		scadaTLSConfig: &tls.Config{},
+	}
+
+	// Apply all options
+	for _, opt := range opts {
+		if err := opt(config); err != nil {
+			return nil, fmt.Errorf("failed to apply configuration option: %w", err)
+		}
+	}
+
+	// Set up a token context with the custom auth TLS config
+	tokenTransport := cleanhttp.DefaultPooledTransport()
+	tokenTransport.TLSClientConfig = config.authTLSConfig
+	tokenContext := context.WithValue(
+		context.Background(),
+		oauth2.HTTPClient,
+		&http.Client{Transport: tokenTransport},
+	)
+
+	// Set token URL based on auth URL
+	tokenURL := config.authURL
+	tokenURL.Path = tokenPath
+	config.clientCredentialsConfig.TokenURL = tokenURL.String()
+
+	// Create token source from the client credentials configuration
+	config.tokenSource = config.clientCredentialsConfig.TokenSource(tokenContext)
+
+	if err := config.validate(); err != nil {
+		return nil, fmt.Errorf("the configuration is not valid: %w", err)
+	}
+
+	return config, nil
+}

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -15,15 +15,15 @@ func TestNew_Default(t *testing.T) {
 	require.NoError(err)
 
 	// Ensure that the default configuration contains the default values
-	require.Equal(defaultPortalURL, config.GetPortalURL().String())
-	require.Equal(defaultAPIAddress, config.GetAPIAddress())
-	require.Equal(defaultSCADAAddress, config.GetSCADAAddress())
+	require.Equal(defaultPortalURL, config.PortalURL().String())
+	require.Equal(defaultAPIAddress, config.APIAddress())
+	require.Equal(defaultSCADAAddress, config.SCADAAddress())
 
 	// Ensure the default configuration uses secure TLS
-	require.NotNil(config.GetAPITLSConfig())
-	require.False(config.GetAPITLSConfig().InsecureSkipVerify)
-	require.NotNil(config.GetSCADATLSConfig())
-	require.False(config.GetSCADATLSConfig().InsecureSkipVerify)
+	require.NotNil(config.APITLSConfig())
+	require.False(config.APITLSConfig().InsecureSkipVerify)
+	require.NotNil(config.SCADATLSConfig())
+	require.False(config.SCADATLSConfig().InsecureSkipVerify)
 }
 
 func TestNew_Options(t *testing.T) {
@@ -39,9 +39,9 @@ func TestNew_Options(t *testing.T) {
 	require.NoError(err)
 
 	// Ensure the values have been set accordingly
-	require.Equal("https://my-portal:1234", config.GetPortalURL().String())
-	require.Equal("my-api:2345", config.GetAPIAddress())
-	require.Equal("my-scada:3456", config.GetSCADAAddress())
+	require.Equal("https://my-portal:1234", config.PortalURL().String())
+	require.Equal("my-api:2345", config.APIAddress())
+	require.Equal("my-scada:3456", config.SCADAAddress())
 }
 
 func TestNew_Invalid(t *testing.T) {

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -1,0 +1,108 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	requirepkg "github.com/stretchr/testify/require"
+)
+
+func TestNew_Default(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config, err := NewHCPConfig(WithClientCredentials("my-client-id", "my-client-secret"))
+	require.NoError(err)
+
+	// Ensure that the default configuration contains the default values
+	require.Equal(defaultPortalURL, config.GetPortalURL().String())
+	require.Equal(defaultAPIAddress, config.GetAPIAddress())
+	require.Equal(defaultSCADAAddress, config.GetSCADAAddress())
+
+	// Ensure the default configuration uses secure TLS
+	require.NotNil(config.GetAPITLSConfig())
+	require.False(config.GetAPITLSConfig().InsecureSkipVerify)
+	require.NotNil(config.GetSCADATLSConfig())
+	require.False(config.GetSCADATLSConfig().InsecureSkipVerify)
+}
+
+func TestNew_Options(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config, err := NewHCPConfig(
+		WithClientCredentials("my-client-id", "my-client-secret"),
+		WithPortalURL("https://my-portal:1234"),
+		WithAPI("my-api:2345", &tls.Config{}),
+		WithSCADA("my-scada:3456", &tls.Config{}),
+	)
+	require.NoError(err)
+
+	// Ensure the values have been set accordingly
+	require.Equal("https://my-portal:1234", config.GetPortalURL().String())
+	require.Equal("my-api:2345", config.GetAPIAddress())
+	require.Equal("my-scada:3456", config.GetSCADAAddress())
+}
+
+func TestNew_Invalid(t *testing.T) {
+	testCases := []struct {
+		name          string
+		options       []HCPConfigOption
+		expectedError string
+	}{
+		{
+			name:          "missing credentials",
+			options:       []HCPConfigOption{},
+			expectedError: "the configuration is not valid: client credentials need to be provided",
+		},
+		{
+			name: "empty portal URL",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithPortalURL(""),
+			},
+			expectedError: "the configuration is not valid: the portal URL has to be non-empty",
+		},
+		{
+			name: "empty auth URL",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithAuth("", nil),
+			},
+			expectedError: "the configuration is not valid: the auth URL has to be non-empty",
+		},
+		{
+			name: "auth URL with invalid scheme",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithAuth("http://auth", nil),
+			},
+			expectedError: "the configuration is not valid: the auth URL has to use https at its scheme",
+		},
+		{
+			name: "empty API address",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithAPI("", nil),
+			},
+			expectedError: "the configuration is not valid: the API address has to be non-empty",
+		},
+		{
+			name: "empty SCADA address",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithSCADA("", nil),
+			},
+			expectedError: "the configuration is not valid: the SCADA address has to be non-empty",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			require := requirepkg.New(t)
+
+			_, err := NewHCPConfig(testCase.options...)
+			require.EqualError(err, testCase.expectedError)
+		})
+	}
+}

--- a/config/options.go
+++ b/config/options.go
@@ -1,0 +1,13 @@
+package config
+
+// HCPConfigOption are functions that modify the hcpConfig struct. They can be
+// passed to NewHCPConfig.
+type HCPConfigOption = func(config *hcpConfig) error
+
+// apply can be used to directly apply an option. This can be helpful to call
+// an option from another one or during tests.
+//
+// E.g. apply(config, WithClientCredentials(clientID, clientSecret))
+func apply(config *hcpConfig, option HCPConfigOption) error {
+	return option(config)
+}

--- a/config/tls.go
+++ b/config/tls.go
@@ -1,0 +1,14 @@
+package config
+
+import "crypto/tls"
+
+// cloneTLSConfig will shallow clone a TLS. tls.Config already has a Clone method
+// but versions before Go 1.15 did not allow to clone nil.
+// TODO: remove once the SDK only supports Go 1.16 and newer.
+func cloneTLSConfig(original *tls.Config) *tls.Config {
+	if original == nil {
+		return nil
+	}
+
+	return original.Clone()
+}

--- a/config/with.go
+++ b/config/with.go
@@ -26,7 +26,7 @@ func WithClientCredentials(clientID, clientSecret string) HCPConfigOption {
 func WithAPI(address string, tlsConfig *tls.Config) HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.apiAddress = address
-		config.apiTLSConfig = tlsConfig.Clone()
+		config.apiTLSConfig = cloneTLSConfig(tlsConfig)
 
 		return nil
 	}
@@ -41,7 +41,7 @@ func WithAPI(address string, tlsConfig *tls.Config) HCPConfigOption {
 func WithSCADA(address string, tlsConfig *tls.Config) HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.scadaAddress = address
-		config.scadaTLSConfig = tlsConfig.Clone()
+		config.scadaTLSConfig = cloneTLSConfig(tlsConfig)
 
 		return nil
 	}
@@ -86,7 +86,7 @@ func WithAuth(authURL string, tlsConfig *tls.Config) HCPConfigOption {
 		}
 
 		config.authURL = parsedAuthURL
-		config.authTLSConfig = tlsConfig
+		config.authTLSConfig = cloneTLSConfig(tlsConfig)
 
 		return nil
 	}

--- a/config/with.go
+++ b/config/with.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/url"
+)
+
+// WithClientCredentials credentials is an option that can be used to set
+// HCP client credentials on the configuration.
+func WithClientCredentials(clientID, clientSecret string) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		config.clientCredentialsConfig.ClientID = clientID
+		config.clientCredentialsConfig.ClientSecret = clientSecret
+
+		return nil
+	}
+}
+
+// WithAPI credentials is an option that can be used to provide a custom
+// configuration for the API endpoint.
+//
+// If nil is provided for the tlsConfig value, TLS will be disabled.
+//
+// This should only be necessary for development purposes.
+func WithAPI(address string, tlsConfig *tls.Config) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		config.apiAddress = address
+		config.apiTLSConfig = tlsConfig.Clone()
+
+		return nil
+	}
+}
+
+// WithSCADA credentials is an option that can be used to provide a custom
+// configuration for the SCADA endpoint.
+//
+// If nil is provided for the tlsConfig value, TLS will be disabled.
+//
+// This should only be necessary for development purposes.
+func WithSCADA(address string, tlsConfig *tls.Config) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		config.scadaAddress = address
+		config.scadaTLSConfig = tlsConfig.Clone()
+
+		return nil
+	}
+}
+
+// WithPortalURL credentials is an option that can be used to provide a custom
+// URL for the portal.
+//
+// This should only be necessary for development purposes.
+func WithPortalURL(portalURL string) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		parsedPortalURL, err := url.Parse(portalURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse portal URL: %w", err)
+		}
+
+		config.portalURL = parsedPortalURL
+
+		return nil
+	}
+}
+
+// WithAuth credentials is an option that can be used to provide a custom URL
+// for the auth endpoint.
+//
+// An alternative TLS configuration can be provided, if non is provided the
+// default TLS configuration will be used. It is not possible to disable TLS for
+// the auth endpoint.
+//
+// This should only be necessary for development purposes.
+func WithAuth(authURL string, tlsConfig *tls.Config) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		parsedAuthURL, err := url.Parse(authURL)
+		if err != nil {
+			return fmt.Errorf("failed to parse auth URL: %w", err)
+		}
+
+		// Ensure a TLS configuration is set, as the auth endpoint should always
+		// use TLS.
+		if tlsConfig == nil {
+			tlsConfig = &tls.Config{}
+		}
+
+		config.authURL = parsedAuthURL
+		config.authTLSConfig = tlsConfig
+
+		return nil
+	}
+}

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	requirepkg "github.com/stretchr/testify/require"
+)
+
+func TestWith_ClientCredentials(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithClientCredentials("my-client-id", "my-client-secret")))
+
+	// Ensure that the client credentials have been set
+	require.Equal("my-client-id", config.clientCredentialsConfig.ClientID)
+	require.Equal("my-client-secret", config.clientCredentialsConfig.ClientSecret)
+}
+
+func TestWith_API(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithAPI("my-api:1234", &tls.Config{})))
+
+	// Ensure that the API configuration have been set
+	require.Equal("my-api:1234", config.apiAddress)
+	require.NotNil(config.GetAPITLSConfig())
+}
+
+func TestWith_SCADA(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithSCADA("my-scada:1234", &tls.Config{})))
+
+	// Ensure that the SCADA configuration have been set
+	require.Equal("my-scada:1234", config.scadaAddress)
+	require.NotNil(config.GetSCADATLSConfig())
+}
+
+func TestWith_PortalURL(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithPortalURL("http://my-portal:1234")))
+
+	// Ensure that the portal URL has been set
+	require.Equal("http://my-portal:1234", config.portalURL.String())
+}
+
+func TestWith_Auth(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithAuth("http://my-auth:1234", nil)))
+
+	// Ensure that the portal URL has been set
+	require.Equal("http://my-auth:1234", config.authURL.String())
+
+	// Ensure auth TLS is configured
+	require.NotNil(config.authTLSConfig)
+}
+
+func TestWith_Auth_CustomTLSConfig(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise
+	config := &hcpConfig{}
+	require.NoError(apply(config, WithAuth("http://my-auth:1234", &tls.Config{InsecureSkipVerify: true})))
+
+	// Ensure auth TLS has custom configuration
+	require.True(config.authTLSConfig.InsecureSkipVerify)
+}

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -28,7 +28,7 @@ func TestWith_API(t *testing.T) {
 
 	// Ensure that the API configuration have been set
 	require.Equal("my-api:1234", config.apiAddress)
-	require.NotNil(config.GetAPITLSConfig())
+	require.NotNil(config.APITLSConfig())
 }
 
 func TestWith_SCADA(t *testing.T) {
@@ -40,7 +40,7 @@ func TestWith_SCADA(t *testing.T) {
 
 	// Ensure that the SCADA configuration have been set
 	require.Equal("my-scada:1234", config.scadaAddress)
-	require.NotNil(config.GetSCADATLSConfig())
+	require.NotNil(config.SCADATLSConfig())
 }
 
 func TestWith_PortalURL(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-openapi/strfmt v0.20.0
 	github.com/go-openapi/swag v0.19.14
 	github.com/go-openapi/validate v0.20.2
-	github.com/go-ozzo/ozzo-validation v3.6.0+incompatible
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/iancoleman/strcase v0.1.3
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -14,5 +14,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.1
 	github.com/iancoleman/strcase v0.1.3
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
 	golang.org/x/oauth2 v0.0.0-20201109201403-9fd604954f58
 )

--- a/go.sum
+++ b/go.sum
@@ -157,8 +157,6 @@ github.com/go-openapi/validate v0.19.15/go.mod h1:tbn/fdOwYHgrhPBzidZfJC2MIVvs9G
 github.com/go-openapi/validate v0.20.1/go.mod h1:b60iJT+xNNLfaQJUqLI7946tYiFEOuE9E4k54HpKcJ0=
 github.com/go-openapi/validate v0.20.2 h1:AhqDegYV3J3iQkMPJSXkvzymHKMTw0BST3RK3hTT4ts=
 github.com/go-openapi/validate v0.20.2/go.mod h1:e7OJoKNgd0twXZwIn0A43tHbvIcr/rZIVCbJBpTUoY0=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible h1:msy24VGS42fKO9K1vLz82/GeYW1cILu7Nuuj1N3BBkE=
-github.com/go-ozzo/ozzo-validation v3.6.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -70,7 +70,7 @@ func New(cfg Config) (runtime *httptransport.Runtime, err error) {
 
 	// Create a transport using the API TLS config.
 	tlsTransport := cleanhttp.DefaultPooledTransport()
-	tlsTransport.TLSClientConfig = cfg.GetAPITLSConfig()
+	tlsTransport.TLSClientConfig = cfg.APITLSConfig()
 
 	// Wrap the transport in an oauth2.Transport.
 	var transport http.RoundTripper = &oauth2.Transport{
@@ -86,12 +86,12 @@ func New(cfg Config) (runtime *httptransport.Runtime, err error) {
 
 	// Set the scheme based on the TLS configuration.
 	scheme := "https"
-	if cfg.GetAPITLSConfig() == nil {
+	if cfg.APITLSConfig() == nil {
 		scheme = "http"
 	}
 
 	// Create a runtime that can be used by the generated clients.
-	runtime = httptransport.New(cfg.GetAPIAddress(), "", []string{scheme})
+	runtime = httptransport.New(cfg.APIAddress(), "", []string{scheme})
 	runtime.Transport = transport
 
 	return runtime, nil

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -1,35 +1,42 @@
 package httpclient
 
 import (
-	"context"
-	"errors"
+	"crypto/tls"
 	"fmt"
 	"net/http"
-	"net/url"
-	"os"
 	"strings"
 
 	httptransport "github.com/go-openapi/runtime/client"
-	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/hashicorp/go-cleanhttp"
 	"golang.org/x/oauth2"
 
-	"github.com/hashicorp/hcp-sdk-go/auth"
+	"github.com/hashicorp/hcp-sdk-go/config"
 	"github.com/hashicorp/hcp-sdk-go/version"
 )
 
 // Config contains the client's configuration options
 type Config struct {
+	// HCPConfig contains values that allow to interact with HCP APIs.
+	config.HCPConfig
+
 	// HostPath is the host name of the HCP API, without a scheme prefix.
+	//
+	// Deprecated: HCPConfig should be used instead
 	HostPath string `json:"host_path"`
 
 	// AuthURL is the URL of the authentication provider, inclusive of the 'https' scheme prefix.
+	//
+	// Deprecated: HCPConfig should be used instead
 	AuthURL string `json:"auth_url"`
 
 	// ClientID is the client ID of a Service Principal Key.
+	//
+	// Deprecated: HCPConfig should be used instead
 	ClientID string `json:"client_id"`
 
 	// ClientSecret is the client secret of a Service Principal Key, only provided on creation.
+	//
+	// Deprecated: HCPConfig should be used instead
 	ClientSecret string `json:"client_secret"`
 
 	// SourceChannel denotes the client (channel) that originiated the request.
@@ -40,6 +47,8 @@ type Config struct {
 	// cleanhttp default one for both Auth and API requests. This should be used only for testing
 	// in testing to provide the httptest.Server's custom client that will trust
 	// its TLS cert.
+	//
+	// Deprecated: HCPConfig should be used instead
 	Client *http.Client
 }
 type roundTripperWithSourceChannel struct {
@@ -54,111 +63,84 @@ func (rt *roundTripperWithSourceChannel) RoundTrip(req *http.Request) (*http.Res
 
 // New creates a client with the right base path to connect to any HCP API
 func New(cfg Config) (runtime *httptransport.Runtime, err error) {
-
 	// Populate default values where possible.
-	cfg.Canonicalize()
-
-	if err := cfg.Validate(); err != nil {
+	if err = cfg.Canonicalize(); err != nil {
 		return nil, fmt.Errorf("invalid config: %w", err)
 	}
 
-	// Initialize an http client with a transport to be shared by the service-specific clients.
-	client := cfg.Client
-	if client == nil {
-		client = cleanhttp.DefaultPooledClient()
-	}
+	// Create a transport using the API TLS config.
+	tlsTransport := cleanhttp.DefaultPooledTransport()
+	tlsTransport.TLSClientConfig = cfg.GetAPITLSConfig()
 
-	// The oauth2 client initializer requires the http client to be passed in via context.
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, client)
-
-	client, err = auth.WithClientCredentials(ctx, cfg.ClientID, cfg.ClientSecret, cfg.AuthURL)
-	if err != nil {
-		return nil, fmt.Errorf("failed to obtain credentials: %w", err)
+	// Wrap the transport in an oauth2.Transport.
+	var transport http.RoundTripper = &oauth2.Transport{
+		Base:   tlsTransport,
+		Source: cfg,
 	}
 
 	if cfg.SourceChannel != "" {
-		// Using a custom transport in order to set the source channel header when it is present.
+		// Use custom transport in order to set the source channel header when it is present.
 		sourceChannel := fmt.Sprintf("%s hcp-go-sdk/%s", cfg.SourceChannel, version.Version)
-		client.Transport = &roundTripperWithSourceChannel{OriginalRoundTripper: client.Transport, SourceChannel: sourceChannel}
+		transport = &roundTripperWithSourceChannel{OriginalRoundTripper: transport, SourceChannel: sourceChannel}
 	}
 
-	// This is the type of runtime that can be used by the generated clients.
-	runtime = httptransport.NewWithClient(cfg.HostPath, "", []string{"https"}, client)
+	// Set the scheme based on the TLS configuration.
+	scheme := "https"
+	if cfg.GetAPITLSConfig() == nil {
+		scheme = "http"
+	}
+
+	// Create a runtime that can be used by the generated clients.
+	runtime = httptransport.New(cfg.GetAPIAddress(), "", []string{scheme})
+	runtime.Transport = transport
 
 	return runtime, nil
 }
 
 // Canonicalize populates default values for config fields that are otherwise unset.
-func (c *Config) Canonicalize() {
-	if c.HostPath == "" {
-		c.HostPath = os.Getenv("HCP_API_HOST")
-		if c.HostPath == "" {
-			// prod default
-			c.HostPath = "api.cloud.hashicorp.com"
-		}
+func (c *Config) Canonicalize() error {
+	// When a HCPConfig is provided it is expected to be canonical and
+	// deprecated configuration values will be ignored.
+	if c.HCPConfig != nil {
+		return nil
 	}
-	if c.AuthURL == "" {
-		c.AuthURL = os.Getenv("HCP_AUTH_URL")
-		if c.AuthURL == "" {
-			// prod default
-			c.AuthURL = "https://auth.hashicorp.com"
-		}
-	}
-	// Allow https:// prefix on HostPath even though it's the only scheme we allow
-	// as it's more natural to support the URL. Any other scheme we don't strip
-	// which will fail validation.
-	if strings.HasPrefix(strings.ToLower(c.HostPath), "https://") {
-		c.HostPath = c.HostPath[8:]
-	}
-}
 
-// Validate ensures the http client configuration is valid.
-func (c *Config) Validate() error {
+	tlsConfig := &tls.Config{}
 
-	if c.ClientID == "" {
-		c.ClientID = os.Getenv("HCP_CLIENT_ID")
-		if c.ClientID == "" {
-			return errors.New("client ID not provided")
+	// Use the test client's TLS configuration, if one was provided
+	if c.Client != nil {
+		httpTransport, ok := c.Client.Transport.(*http.Transport)
+		if ok {
+			tlsConfig = httpTransport.TLSClientConfig
 		}
 	}
 
-	if c.ClientSecret == "" {
-		c.ClientSecret = os.Getenv("HCP_CLIENT_SECRET")
-		if c.ClientSecret == "" {
-			return errors.New("client secret not provided")
+	// Otherwise, construct a HCPConfig
+	options := []config.HCPConfigOption{config.FromEnv()}
+
+	if c.HostPath != "" {
+		// Allow https:// prefix on HostPath even though it's the only scheme we allow
+		// as it's more natural to support the URL. Any other scheme we don't strip
+		// which will fail validation.
+		if strings.HasPrefix(strings.ToLower(c.HostPath), "https://") {
+			c.HostPath = c.HostPath[8:]
 		}
+
+		options = append(options, config.WithAPI(c.HostPath, tlsConfig))
 	}
 
-	return validation.ValidateStruct(c,
-		// The scheme will be appended by the go-openapi client, so it must not be included in the host path.
-		validation.Field(&c.HostPath, validation.Required, validation.By(excludesScheme)),
-		// For security, the authentication provider's Token URL must use 'https'.
-		validation.Field(&c.AuthURL, validation.Required, validation.By(includesHTTPSScheme)),
-	)
-}
-
-func excludesScheme(value interface{}) error {
-	u, _ := value.(string)
-
-	// We expect this to NOT have a scheme which means it's not a valid URL and
-	// url.Parse explicitly doesn't support this in its docs.
-	if strings.Contains(u, "://") {
-		return fmt.Errorf("%q must not include any scheme", u)
+	if c.AuthURL != "" {
+		options = append(options, config.WithAuth(c.AuthURL, tlsConfig))
 	}
 
-	return nil
-}
+	if c.ClientID != "" && c.ClientSecret != "" {
+		options = append(options, config.WithClientCredentials(c.ClientID, c.ClientSecret))
+	}
 
-func includesHTTPSScheme(value interface{}) error {
-	u, _ := value.(string)
-
-	p, err := url.Parse(u)
+	var err error
+	c.HCPConfig, err = config.NewHCPConfig(options...)
 	if err != nil {
-		return fmt.Errorf("failed to parse %q: %w", u, err)
-	}
-
-	if p.Scheme != "https" {
-		return fmt.Errorf("%q must start with 'https' scheme", u)
+		return fmt.Errorf("failed to construct HCP config: %w", err)
 	}
 
 	return nil

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -1,15 +1,20 @@
 package httpclient
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"sync/atomic"
 	"testing"
 
-	consul "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client/consul_service"
 	"github.com/stretchr/testify/require"
+
+	consul "github.com/hashicorp/hcp-sdk-go/clients/cloud-consul-service/preview/2020-08-26/client/consul_service"
+	"github.com/hashicorp/hcp-sdk-go/config"
 )
 
 func TestNew(t *testing.T) {
@@ -65,32 +70,83 @@ func TestNew(t *testing.T) {
 	ts.StartTLS()
 	defer ts.Close()
 
-	cfg := Config{
-		HostPath:     ts.URL,
-		AuthURL:      ts.URL,
-		ClientID:     clientID,
-		ClientSecret: clientSecret,
-		// Override the base http.Client so that we trust the test server's TLS
-		Client: ts.Client(),
-	}
+	t.Run("legacy configuration", func(t *testing.T) {
+		numRequests = 0
 
-	// The test's important assertions occur in the test server handler above.
-	// When an http client is initialized, it tries to obtain an access token using the configured token URL (from an auth provider), client ID, and client secret.
-	// The token request embedded in this client initializer hits the mock auth provider handler above ('/oauth/token').
-	cl, err := New(cfg)
-	require.NoError(t, err)
+		cfg := Config{
+			HostPath:     ts.URL,
+			AuthURL:      ts.URL,
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			// Override the base http.Client so that we trust the test server's TLS
+			Client: ts.Client(),
+		}
 
-	consulClient := consul.New(cl, nil)
-	listParams := consul.NewListParams()
-	listParams.LocationOrganizationID = orgID
-	listParams.LocationProjectID = projID
+		// The test's important assertions occur in the test server handler above.
+		// When an http client is initialized, it tries to obtain an access token using the configured token URL (from an auth provider), client ID, and client secret.
+		// The token request embedded in this client initializer hits the mock auth provider handler above ('/oauth/token').
+		cl, err := New(cfg)
+		require.NoError(t, err)
 
-	// This SDK request hits the mock Consul List API handler above ('/consul/2020-08-26/organizations...').
-	// The handler verifies that the expected bearer token is provided.
-	_, err = consulClient.List(listParams, nil)
-	require.NoError(t, err)
+		consulClient := consul.New(cl, nil)
+		listParams := consul.NewListParams()
+		listParams.LocationOrganizationID = orgID
+		listParams.LocationProjectID = projID
 
-	// Make sure we actually handled both the auth and the GET request and didn't
-	// just skip all the assertions!
-	require.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
+		// This SDK request hits the mock Consul List API handler above ('/consul/2020-08-26/organizations...').
+		// The handler verifies that the expected bearer token is provided.
+		_, err = consulClient.List(listParams, nil)
+		require.NoError(t, err)
+
+		// Make sure we actually handled both the auth and the GET request and didn't
+		// just skip all the assertions!
+		require.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
+	})
+
+	t.Run("HCPConfig", func(t *testing.T) {
+		numRequests = 0
+
+		serverURL, err := url.Parse(ts.URL)
+		require.NoError(t, err)
+
+		// Compile a custom TLS config that trusts the test server's certificate
+		certPool := x509.NewCertPool()
+		certPool.AddCert(ts.Certificate())
+
+		tlsConfig := &tls.Config{
+			RootCAs: certPool,
+		}
+
+		// Create a config that calls the test server
+		hcpConfig, err := config.NewHCPConfig(
+			config.WithClientCredentials(clientID, clientSecret),
+			config.WithAuth(ts.URL, tlsConfig),
+			config.WithAPI(serverURL.Host, tlsConfig),
+		)
+		require.NoError(t, err)
+
+		cfg := Config{
+			HCPConfig: hcpConfig,
+		}
+
+		// The test's important assertions occur in the test server handler above.
+		// When an http client is initialized, it tries to obtain an access token using the configured token URL (from an auth provider), client ID, and client secret.
+		// The token request embedded in this client initializer hits the mock auth provider handler above ('/oauth/token').
+		cl, err := New(cfg)
+		require.NoError(t, err)
+
+		consulClient := consul.New(cl, nil)
+		listParams := consul.NewListParams()
+		listParams.LocationOrganizationID = orgID
+		listParams.LocationProjectID = projID
+
+		// This SDK request hits the mock Consul List API handler above ('/consul/2020-08-26/organizations...').
+		// The handler verifies that the expected bearer token is provided.
+		_, err = consulClient.List(listParams, nil)
+		require.NoError(t, err)
+
+		// Make sure we actually handled both the auth and the GET request and didn't
+		// just skip all the assertions!
+		require.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
+	})
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

A new `HCPConfig` interface (and an implementing internal struct) have been added to the SDK. This configuration is supposed to be used as a common source of HCP specific configuration values for the SDK itself as well as other tools that need access to HCP.

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):

```release-note
BREAKING CHANGES:
 * A new configuration interface HCPConfig has been introduced. The change should be backwards compatible, but existing configuration fields of the httpclient.Config have been deprecated and should be replaced by the respective HCPConfig version.
```

### :+1: Definition of Done

- [x] Tests added