### PR TITLE
fix pipeline

### DIFF
--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: hashicorp/cloud-api
-          ref: auto-update-${{ github.event.inputs.service }}-sdk
+          ref: auto-update-${{ github.event.inputs.service }}-specs
           token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
           path: cloud-api
 


### PR DESCRIPTION
### :hammer_and_wrench: Description

Fixes a bug in the cloud-api branch name causing the pipeline to fail. Also fixes the open-pr script so it can actually push a PR! :)

### :link: External Links

https://github.com/hashicorp/hcp-sdk-go/actions/runs/2511808525