### PR TITLE
Bump version to 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.20.0 (June 17, 2022)
+## 0.20.0 (June 20, 2022)
 
 FEATURES:
 * Updated cloud-vault-service/stable/2020-11-25 to add major version upgrade features ([#95](https://github.com/hashicorp/hcp-sdk-go/pull/95)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.20.0 (June 17, 2022)
+
+FEATURES:
+* Updated cloud-vault-service/stable/2020-11-25 to add major version upgrade features ([#95](https://github.com/hashicorp/hcp-sdk-go/pull/95)).
+
 ## 0.19.0 (May 6, 2022)
 
 BREAKING CHANGES:

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version refers to the current version of hcp-sdk-go.
-var Version = "0.18.0"
+var Version = "0.19.0"

--- a/version/version.go
+++ b/version/version.go
@@ -1,4 +1,4 @@
 package version
 
 // Version refers to the current version of hcp-sdk-go.
-var Version = "0.19.0"
+var Version = "0.20.0"


### PR DESCRIPTION
Updates changelog and bumps version to 0.20.0 to include major version upgrade features in vault-service. 