### PR TITLE
resource: add new package to help handle resource link encoding

### DIFF
--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,0 +1,136 @@
+package resource
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/go-ozzo/ozzo-validation/is"
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+)
+
+const (
+	tokenOrganization = "organization"
+	tokenProject      = "project"
+	tokenSep          = "/"
+)
+
+// Resource is a representation of a HCP resource identifier
+type Resource struct {
+	// ID uniquely identifies a resource within an HCP project
+	ID string
+	// Type is the name of the kind of resource identified
+	Type string
+	// Organization is the UUID of the HCP organization the resource belongs to
+	Organization string
+	// Project is the UUID of the HCP project the resource belongs to
+	Project string
+}
+
+// String encodes the resource identifier in the following canonical format:
+//     "organization/<Organization UUID>/project/<Project UUID>/<Type>/<ID>"
+// Example:
+//     "organization/ccbdd191-5dc3-4a73-9e05-6ac30ca67992/project/36019e0d-ed59-4df6-9990-05bb7fc793b6/hashicorp.consul.linked-cluster/prod-on-prem"
+func (r Resource) String() string {
+	return strings.Join([]string{
+		tokenOrganization, r.Organization,
+		tokenProject, r.Project,
+		r.Type, r.ID,
+	}, tokenSep)
+}
+
+// Location returns a *models.HashicorpCloudLocationLocation initialized with the Resource's organization and project IDs.
+func (r Resource) Location() *models.HashicorpCloudLocationLocation {
+	return &models.HashicorpCloudLocationLocation{OrganizationID: r.Organization, ProjectID: r.Project}
+}
+
+// Link returns a *models.HashicorpCloudLocationLink initialized with values from the Resource
+func (r Resource) Link() *models.HashicorpCloudLocationLink {
+	return &models.HashicorpCloudLocationLink{
+		ID:       r.ID,
+		Type:     r.Type,
+		Location: r.Location(),
+	}
+}
+
+// FromLink converts a models.HashicorpCloudLocationLink to a Resource.
+func FromLink(l *models.HashicorpCloudLocationLink) (r Resource, err error) {
+	if l == nil || l.Location == nil {
+		return r, parseErr(errors.New("link and link.Location must not be nil"))
+	}
+	return Resource{
+		ID:           l.ID,
+		Type:         l.Type,
+		Organization: l.Location.OrganizationID,
+		Project:      l.Location.ProjectID,
+	}, nil
+}
+
+// FromString parses the string encoding of a resource identifier.
+func FromString(str string) (r Resource, err error) {
+	err = r.UnmarshalText([]byte(str))
+	return r, err
+}
+
+// UnmarshalText implements the encoding.TextUnmarshaler interface and parses an encoded Resource.
+func (r *Resource) UnmarshalText(text []byte) error {
+	if r == nil {
+		return fmt.Errorf("resource cannot be nil")
+	}
+
+	parts := strings.SplitN(string(text), tokenSep, 6)
+	if len(parts) != 6 {
+		return parseErr(fmt.Errorf("unexpected number of tokens %d", len(parts)))
+	}
+
+	if parts[0] != tokenOrganization {
+		return parseErr(fmt.Errorf("unexpected token %q", parts[0]))
+	}
+	if err := validation.Validate(parts[1], is.UUID); err != nil {
+		return parseErr(err)
+	}
+	if parts[2] != tokenProject {
+		return parseErr(fmt.Errorf("unexpected token %q", parts[2]))
+	}
+	if err := validation.Validate(parts[3], is.UUID); err != nil {
+		return parseErr(err)
+	}
+
+	r.Organization = parts[1]
+	r.Project = parts[3]
+	r.Type = parts[4]
+	r.ID = parts[5]
+	return nil
+}
+
+func parseErr(err error) error {
+	return fmt.Errorf("could not parse resource: %w", err)
+}
+
+// MarshalText implements the encoding.TextMarshaler interface.
+// The encoding is the same as returned by String.
+func (r *Resource) MarshalText() ([]byte, error) {
+	return []byte(r.String()), nil
+}
+
+// MarshalJSON implements the json.Marshaler interface
+func (r *Resource) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + r.String() + "\""), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface
+func (r *Resource) UnmarshalJSON(bytes []byte) error {
+	return r.UnmarshalText(bytes[1 : len(bytes)-1])
+}
+
+// Must is a helper function that wraps a call to a function returning (Resource, error) such as FromLink or FromString
+// and panics if the error is non-nil. It is intended for use in variable
+// initializations such as
+//	var packageResource = resource.Must(resource.FromString("..."))
+func Must(r Resource, err error) Resource {
+	if err != nil {
+		panic(err)
+	}
+	return r
+}

--- a/resource/resource_test.go
+++ b/resource/resource_test.go
@@ -1,0 +1,156 @@
+package resource
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/hcp-sdk-go/clients/cloud-shared/v1/models"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	_ encoding.TextMarshaler   = &Resource{}
+	_ encoding.TextUnmarshaler = &Resource{}
+	_ json.Marshaler           = &Resource{}
+	_ json.Unmarshaler         = &Resource{}
+	_ fmt.Stringer             = &Resource{}
+)
+
+func testResource() Resource {
+	return Resource{
+		ID:           "foo",
+		Type:         "resource.example",
+		Organization: "209ffeb2-542e-4e81-a99d-ce9374c6ea7c",
+		Project:      "262305a9-76e1-4a3b-b940-df55d493edb8",
+	}
+}
+
+func TestFromString(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    string
+		expected Resource
+		errStr   string
+	}{
+		{
+			name:     "normal case",
+			input:    "organization/209ffeb2-542e-4e81-a99d-ce9374c6ea7c/project/262305a9-76e1-4a3b-b940-df55d493edb8/resource.example/foo",
+			expected: testResource(),
+		},
+		{
+			name:   "bad organization token",
+			input:  "org/209ffeb2-542e-4e81-a99d-ce9374c6ea7c/project/262305a9-76e1-4a3b-b940-df55d493edb8/resource.example/foo",
+			errStr: "unexpected token",
+		},
+		{
+			name:   "bad organization id",
+			input:  "organization/abc123/project/262305a9-76e1-4a3b-b940-df55d493edb8/resource.example/foo",
+			errStr: "must be a valid UUID",
+		},
+		{
+			name:   "bad project token",
+			input:  "organization/209ffeb2-542e-4e81-a99d-ce9374c6ea7c/proj/262305a9-76e1-4a3b-b940-df55d493edb8/resource.example/foo",
+			errStr: "unexpected token",
+		},
+		{
+			name:   "bad project id",
+			input:  "organization/262305a9-76e1-4a3b-b940-df55d493edb8/project/abc123/resource.example/foo",
+			errStr: "must be a valid UUID",
+		},
+		{
+			name:   "bad ID format",
+			input:  "foobar",
+			errStr: "unexpected number of tokens",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(tc *testing.T) {
+			res, err := FromString(c.input)
+			if len(c.errStr) == 0 {
+				require.NoError(tc, err)
+				require.Equal(tc, c.expected.String(), res.String())
+			} else {
+				require.Error(tc, err)
+				require.Contains(tc, err.Error(), c.errStr)
+			}
+		})
+	}
+}
+
+func TestFromLink(t *testing.T) {
+	cases := []struct {
+		name     string
+		input    *models.HashicorpCloudLocationLink
+		expected Resource
+		errStr   string
+	}{
+		{
+			name: "normal case",
+			input: &models.HashicorpCloudLocationLink{
+				ID:   "foo",
+				Type: "resource.example",
+				Location: &models.HashicorpCloudLocationLocation{
+					ProjectID:      "262305a9-76e1-4a3b-b940-df55d493edb8",
+					OrganizationID: "209ffeb2-542e-4e81-a99d-ce9374c6ea7c",
+				},
+			},
+			expected: testResource(),
+		},
+		{
+			name:   "nil link",
+			errStr: "must not be nil",
+		},
+		{
+			name:   "nil link.Location",
+			input:  &models.HashicorpCloudLocationLink{},
+			errStr: "must not be nil",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(tc *testing.T) {
+			res, err := FromLink(c.input)
+			if len(c.errStr) == 0 {
+				require.NoError(tc, err)
+				require.Equal(tc, c.expected.String(), res.String())
+			} else {
+				require.Error(tc, err)
+				require.Contains(tc, err.Error(), c.errStr)
+			}
+		})
+	}
+}
+
+type testResourceStruct struct {
+	ID Resource
+}
+
+func TestResourceEncoding(t *testing.T) {
+	expectedStr := "organization/209ffeb2-542e-4e81-a99d-ce9374c6ea7c/project/262305a9-76e1-4a3b-b940-df55d493edb8/resource.example/foo"
+	require.Equal(t, expectedStr, testResource().String())
+
+	obj := testResourceStruct{
+		ID: testResource(),
+	}
+	data, err := json.Marshal(&obj)
+	require.NoError(t, err)
+	dataMap := map[string]string{}
+	require.NoError(t, json.Unmarshal(data, &dataMap))
+	require.Equal(t, expectedStr, dataMap["ID"])
+
+	var obj2 testResourceStruct
+	require.NoError(t, json.Unmarshal(data, &obj2))
+	require.Equal(t, obj, obj2)
+}
+
+func TestMust(t *testing.T) {
+	require.NotPanics(t, func() {
+		Must(FromString(testResource().String()))
+	})
+	require.Panics(t, func() {
+		Must(FromString("abc"))
+	})
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR introduces a new `resource` package to help with parsing resource IDs. This is a new ID format that will be used in future APIs and takes the form of:

```
    organization/<org UUID>/project/<proj UUID>/<resource type>/<resource name>
```

The resource type follows the format: `service_name.model`
The resource name follows the format prescribed by the owning service.

The goal of this package is to prevent duplication of encoding/decoding between API producers and consumers. 

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
Add new `resource` package to be used when parsing or working with resource IDs.
```

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [x] Tests added