### PR TITLE
Use HCP token endpoint

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	tokenPath string = "/oauth/token"
+	tokenPath string = "/oauth2/token"
 )
 
 // WithClientCredentials returns an http client with an access token obtained using the configured client credentials.

--- a/config/new.go
+++ b/config/new.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	// defaultAuthURL is the URL of the production auth endpoint.
-	defaultAuthURL = "https://auth.hashicorp.com"
+	defaultAuthURL = "https://auth.idp.hashicorp.com"
 
 	// defaultPortalURL is the URL of the production portal.
 	defaultPortalURL = "https://portal.cloud.hashicorp.com"
@@ -31,7 +31,7 @@ const (
 	aud = "https://api.hashicorp.cloud"
 
 	// tokenPath is the path used to retrieve the access token.
-	tokenPath string = "/oauth/token"
+	tokenPath string = "/oauth2/token"
 )
 
 // NewHCPConfig will return a HCPConfig. The configuration will be constructed

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestNew(t *testing.T) {
 
-	tokenPath := "/oauth/token"
+	tokenPath := "/oauth2/token"
 	token := "90d64460d14870c08c81352a05dedd3465940a7c"
 	clientID := "CLIENT_ID"
 	clientSecret := "CLIENT_SECRET"


### PR DESCRIPTION
### :hammer_and_wrench: Description

Changes the token endpoint from Auth0 to an endpoint on HCP.

### :link: External Links

[Jira ticket](https://hashicorp.atlassian.net/browse/HCPID-1244)
[Relevant RFC section](https://docs.google.com/document/d/1OXIUD-VN0jVb44p9n3AgzDobu60K4qqP0cl37CRTM8s/edit#heading=h.udjfjks7tu8s)

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
BREAKING CHANGES:
* Change token endpoint from Auth0 to HCP
```

### Definition of Done
- [X] Tests update
- [X] Tested locally