### PR TITLE
Use public scada address - scada.hashicorp.cloud

### DIFF
--- a/config/new.go
+++ b/config/new.go
@@ -27,7 +27,7 @@ const (
 	defaultAPIAddress = "api.cloud.hashicorp.com:443"
 
 	// defaultSCADAAddress is the address of the production SCADA endpoint.
-	defaultSCADAAddress = "scada.internal.hashicorp.cloud:7224"
+	defaultSCADAAddress = "scada.hashicorp.cloud:7224"
 
 	// The audience is the API identifier configured in the auth provider and
 	// must be provided when requesting an access token for the API. The value


### PR DESCRIPTION
### :hammer_and_wrench: Description

Update the default scada address to "scada.hashicorp.cloud" to remove the "internal" part of it. Note that existing URL will continue to work as its used by HCP dataplanes but we would like to avoid publishing an "internal" address to the public if possible. This is part of implementing https://hashicorp.atlassian.net/browse/HCPCO2-159.

⚠️ This should not be merged until https://github.com/hashicorp/cloud-scada-broker/pull/249 is merged and new domain being available until prod run of https://github.com/hashicorp/cloud-terraform/pull/2713 goes through.

### :link: External Links

https://hashicorp.atlassian.net/browse/HCPCO2-159

### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):
<!--
If change is not user facing, just write "NONE" in the release-note block below.
-->

```release-note
NONE
```

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?