### PR TITLE
HCE-267: Auth Cache Library

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -96,6 +96,8 @@ func GetTokenFromBrowser(ctx context.Context, conf *oauth2.Config) (*oauth2.Toke
 			return nil, fmt.Errorf("failed to exchange code for token: %w", err)
 		}
 
+		// TODO: save the token somewhere
+
 		return tok, nil
 	case <-sigintCh:
 		return nil, errors.New("interrupted")

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"time"
+
+	"golang.org/x/oauth2"
 )
 
 // import (
@@ -30,7 +32,17 @@ type Cache struct {
 	MaxAge time.Time `json:"max_age,omitempty"`
 }
 
-// 1. Write to json file in a specific location in home directory (OS-dependent)
+// Write saves HCP auth data in a common location in the home directory
+func Write(token oauth2.Token) error {
+	// get the user's home directory
+	// check err
+	// check if the hcp/credentials.json exists
+	// create it if it doesn't
+
+	// write access token, refresh_token, expiry, max age to credentials file
+
+	return nil
+}
 
 // Setter for access_token
 

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,16 +1,26 @@
 package auth
 
+import "time"
+
 // import (
 // 	"encoding/json"
 // 	"fmt"
 // 	"os"
 // )
 
-// type cache struct
-// access token
-// refresh token
-// expiration time
-// max age
+type Cache struct {
+	// AccessToken is the bearer token used to authenticate to HCP.
+	AccessToken string `json:"access_token,omitempty"`
+
+	// RefreshToken is used to get a new access token.
+	RefreshToken string `json:"refresh_token,omitempty"`
+
+	// Expiry is when the access token will expire.
+	Expiry time.Time `json:"expiry,omitempty"`
+
+	// MaxAge is the session limit.
+	MaxAge time.Time `json:"max_age,omitempty"`
+}
 
 // 1. Write to json file in a specific location in home directory (OS-dependent)
 

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,0 +1,43 @@
+package auth
+
+// import (
+// 	"encoding/json"
+// 	"fmt"
+// 	"os"
+// )
+
+// type cache struct
+// access token
+// refresh token
+// expiration time
+// max age
+
+// 1. Write to json file in a specific location in home directory (OS-dependent)
+
+// Setter for access_token
+
+// Setter for refresh_token
+
+// Setter for expiration time
+
+// 2. Read from json file in a specific location in home directory (OS-dependent)
+
+// Getter for access_token
+
+// Getter for refresh_token
+
+// Getter for expiration time
+
+// Constant for max age - 24 hours
+
+// Constant for file name {HOME}"/hcp/credentials.json"
+
+// 3. helpers
+
+// check if directory exists
+
+// create directory + file
+
+// tokenToJson
+
+// JsonToToken

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -55,12 +55,13 @@ func Write(token oauth2.Token) error {
 		Expiry:       token.Expiry,
 		MaxAge:       MaxAge,
 	}
-	credentialsJson, err := json.Marshal(credentials)
+
+	credentialsJSON, err := json.Marshal(credentials)
 	if err != nil {
 		return fmt.Errorf("failed to marshal the struct to json: %v", err)
 	}
 
-	err = os.WriteFile(credentialPath, credentialsJson, directoryPermissions)
+	err = os.WriteFile(credentialPath, credentialsJSON, directoryPermissions)
 	if err != nil {
 		return fmt.Errorf("failed to write credentials to the cache file: %v", err)
 	}
@@ -152,10 +153,10 @@ func tokenToJSON(token *oauth2.Token) ([]byte, error) {
 		Expiry:       token.Expiry,
 		MaxAge:       MaxAge,
 	}
-	credentialsJson, err := json.Marshal(credentials)
+	credentialsJSON, err := json.Marshal(credentials)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal the struct to json: %v", err)
 	}
 
-	return credentialsJson, nil
+	return credentialsJSON, nil
 }

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,6 +1,10 @@
 package auth
 
 import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -35,11 +39,28 @@ type Cache struct {
 // Write saves HCP auth data in a common location in the home directory
 func Write(token oauth2.Token) error {
 	// get the user's home directory
+	userHome, err := os.UserHomeDir()
 	// check err
+	if err != nil {
+		return fmt.Errorf("failed to retriever user's home directory path: %v", err)
+	}
 	// check if the hcp/credentials.json exists
-	// create it if it doesn't
+	credentialPath := filepath.Join(userHome, directoryName, fileName)
+	// open file and create if not already existing
+	credentialFile, err := os.OpenFile(credentialPath, os.O_CREATE, 0755)
 
+	if err != nil {
+		return fmt.Errorf("failed to open user credential file: %v", err)
+	}
 	// write access token, refresh_token, expiry, max age to credentials file
+	res1D := &Cache{
+		AccessToken:  token.AccessToken,
+		RefreshToken: token.RefreshToken,
+		Expiry:       token.Expiry,
+		MaxAge:       MaxAge,
+	}
+	res1B, _ := json.Marshal(res1D)
+	fmt.Println(string(res1B))
 
 	return nil
 }

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -1,12 +1,20 @@
 package auth
 
-import "time"
+import (
+	"time"
+)
 
 // import (
 // 	"encoding/json"
 // 	"fmt"
 // 	"os"
 // )
+
+const (
+	MaxAge        = time.Hour * 24
+	directoryName = "hcp"
+	fileName      = "credentials.json"
+)
 
 type Cache struct {
 	// AccessToken is the bearer token used to authenticate to HCP.
@@ -37,10 +45,6 @@ type Cache struct {
 // Getter for refresh_token
 
 // Getter for expiration time
-
-// Constant for max age - 24 hours
-
-// Constant for file name {HOME}"/hcp/credentials.json"
 
 // 3. helpers
 

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -33,7 +33,7 @@ type Cache struct {
 	Expiry time.Time `json:"expiry,omitempty"`
 
 	// MaxAge is the session limit.
-	MaxAge time.Time `json:"max_age,omitempty"`
+	MaxAge time.Duration `json:"max_age,omitempty"`
 }
 
 // Write saves HCP auth data in a common location in the home directory

--- a/auth/cache.go
+++ b/auth/cache.go
@@ -81,7 +81,7 @@ func Read() (*Cache, error) {
 		return nil, fmt.Errorf("failed to read file from user's credential path: %v", err)
 	}
 
-	cacheFromJSON, err := jsonToToken(rawJSON)
+	cacheFromJSON, err := jsonToCache(rawJSON)
 	if err != nil {
 		return nil, fmt.Errorf("bad format: %v", err)
 	}
@@ -89,7 +89,7 @@ func Read() (*Cache, error) {
 	return cacheFromJSON, nil
 }
 
-// getDirectory returns the complete credential path and directory.
+// getCredentialPaths returns the complete credential path and directory.
 func getCredentialPaths() (credentialPath string, credentialDirectory string, err error) {
 	// Get the user's home directory.
 	userHome, err := os.UserHomeDir()
@@ -112,8 +112,8 @@ func getCredentialPaths() (credentialPath string, credentialDirectory string, er
 	return credentialPath, credentialDirectory, nil
 }
 
-// jsonToToken converts the raw JSON into the Cache struct.
-func jsonToToken(rawData []byte) (*Cache, error) {
+// jsonToCache converts the raw JSON into the Cache struct.
+func jsonToCache(rawData []byte) (*Cache, error) {
 
 	var cacheFromJSON Cache
 	err := json.Unmarshal(rawData, &cacheFromJSON)

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -25,19 +25,21 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	require.NoError(err)
 
 	now := time.Now()
-	tok := oauth2.Token{
-		AccessToken:  "TopSecret!",
-		RefreshToken: "SoRefreshing:)",
-		Expiry:       now,
+	cache := Cache{
+		AccessToken:       "TopSecret!",
+		RefreshToken:      "SoRefreshing:)",
+		AccessTokenExpiry: now,
+		SessionExpiry:     now,
 	}
-	assert.NoError(Write(tok))
+	assert.NoError(Write(cache))
 
-	tok2 := oauth2.Token{
-		AccessToken:  "AnotherTopSecret!",
-		RefreshToken: "StillSoRefreshing:)",
-		Expiry:       now,
+	cache2 := Cache{
+		AccessToken:       "AnotherTopSecret!",
+		RefreshToken:      "StillSoRefreshing:)",
+		AccessTokenExpiry: now,
+		SessionExpiry:     now,
 	}
-	assert.NoError(Write(tok2))
+	assert.NoError(Write(cache2))
 
 	assert.DirExists(credentialDirectory)
 	assert.FileExists(credentialPath)
@@ -50,16 +52,10 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	err = json.Unmarshal(rawJSON, &cacheFromJSON)
 	require.NoError(err)
 
-	expectedCache := Cache{
-		AccessToken:  tok2.AccessToken,
-		RefreshToken: tok2.RefreshToken,
-		Expiry:       tok2.Expiry,
-		MaxAge:       MaxAge,
-	}
-	assert.Equal(expectedCache.AccessToken, cacheFromJSON.AccessToken)
-	assert.Equal(expectedCache.RefreshToken, cacheFromJSON.RefreshToken)
-	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
-	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
+	assert.Equal(cache2.AccessToken, cacheFromJSON.AccessToken)
+	assert.Equal(cache2.RefreshToken, cacheFromJSON.RefreshToken)
+	assert.Equal(cache2.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
+	assert.Equal(cache2.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	require.NoError(destroy())
 }
 
@@ -72,13 +68,14 @@ func TestWrite_NoDirectoryNoFile(t *testing.T) {
 	require.NotNil(credentialDirectory)
 
 	now := time.Now()
-	tok := oauth2.Token{
-		AccessToken:  "TopSecret!",
-		RefreshToken: "SoRefreshing:)",
-		Expiry:       now,
+	cache := Cache{
+		AccessToken:       "TopSecret!",
+		RefreshToken:      "SoRefreshing:)",
+		AccessTokenExpiry: now,
+		SessionExpiry:     now,
 	}
 
-	assert.NoError(Write(tok))
+	assert.NoError(Write(cache))
 	assert.DirExists(credentialDirectory)
 	assert.FileExists(credentialPath)
 
@@ -90,16 +87,10 @@ func TestWrite_NoDirectoryNoFile(t *testing.T) {
 	err = json.Unmarshal(rawJSON, &cacheFromJSON)
 	require.NoError(err)
 
-	expectedCache := Cache{
-		AccessToken:  tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		Expiry:       tok.Expiry,
-		MaxAge:       MaxAge,
-	}
-	assert.Equal(expectedCache.AccessToken, cacheFromJSON.AccessToken)
-	assert.Equal(expectedCache.RefreshToken, cacheFromJSON.RefreshToken)
-	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
-	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
+	assert.Equal(cache.AccessToken, cacheFromJSON.AccessToken)
+	assert.Equal(cache.RefreshToken, cacheFromJSON.RefreshToken)
+	assert.Equal(cache.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
+	assert.Equal(cache.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	require.NoError(destroy())
 }
 
@@ -115,13 +106,14 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 	require.NoError(err)
 
 	now := time.Now()
-	tok := oauth2.Token{
-		AccessToken:  "TopSecret!",
-		RefreshToken: "SoRefreshing:)",
-		Expiry:       now,
+	cache := Cache{
+		AccessToken:       "TopSecret!",
+		RefreshToken:      "SoRefreshing:)",
+		AccessTokenExpiry: now,
+		SessionExpiry:     now,
 	}
 
-	assert.NoError(Write(tok))
+	assert.NoError(Write(cache))
 	assert.DirExists(credentialDirectory)
 	assert.FileExists(credentialPath)
 
@@ -133,16 +125,10 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 	err = json.Unmarshal(rawJSON, &cacheFromJSON)
 	require.NoError(err)
 
-	expectedCache := Cache{
-		AccessToken:  tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		Expiry:       tok.Expiry,
-		MaxAge:       MaxAge,
-	}
-	assert.Equal(expectedCache.AccessToken, cacheFromJSON.AccessToken)
-	assert.Equal(expectedCache.RefreshToken, cacheFromJSON.RefreshToken)
-	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
-	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
+	assert.Equal(cache.AccessToken, cacheFromJSON.AccessToken)
+	assert.Equal(cache.RefreshToken, cacheFromJSON.RefreshToken)
+	assert.Equal(cache.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
+	assert.Equal(cache.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	require.NoError(destroy())
 }
 
@@ -155,28 +141,22 @@ func TestRead_ValidFormat(t *testing.T) {
 	require.NotNil(credentialDirectory)
 
 	now := time.Now()
-	tok := oauth2.Token{
-		AccessToken:  "TopSecret!",
-		RefreshToken: "SoRefreshing:)",
-		Expiry:       now,
+	cache := Cache{
+		AccessToken:       "TopSecret!",
+		RefreshToken:      "SoRefreshing:)",
+		AccessTokenExpiry: now,
+		SessionExpiry:     now,
 	}
 
-	assert.NoError(Write(tok))
+	assert.NoError(Write(cache))
 
 	cachePointer, err := Read()
 	require.NoError(err)
 
-	expectedCache := Cache{
-		AccessToken:  tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		Expiry:       tok.Expiry,
-		MaxAge:       MaxAge,
-	}
-
-	assert.Equal(expectedCache.AccessToken, cachePointer.AccessToken)
-	assert.Equal(expectedCache.RefreshToken, cachePointer.RefreshToken)
-	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cachePointer.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
-	assert.Equal(expectedCache.MaxAge.String(), cachePointer.MaxAge.String())
+	assert.Equal(cache.AccessToken, cachePointer.AccessToken)
+	assert.Equal(cache.RefreshToken, cachePointer.RefreshToken)
+	assert.Equal(cache.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cachePointer.AccessTokenExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
+	assert.Equal(cache.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"), cachePointer.SessionExpiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	require.NoError(destroy())
 }
 
@@ -254,22 +234,22 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		},
 		{
 			name:          "empty values",
-			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "", "expiry": "", "max_age": "" }`),
+			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "", "access_token_expiry": "", "session_expiry": "" }`),
 			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
 		},
 		{
 			name:          "empty access token",
-			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "myrefreshtoken", "expiry": "2022-10-20T17:10:59.273429-04:00", "max_age": 86400000000000 }`),
+			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "myrefreshtoken", "access_token_expiry": "2022-10-20T17:10:59.273429-04:00", "session_expiry": "2022-11-20T17:10:59.273429-04:00"}`),
 			expectedError: "failed to get cache access token",
 		},
 		{
 			name:          "empty refresh token",
-			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "", "expiry": "2022-10-20T17:10:59.273429-04:00", "max_age": 86400000000000 }`),
+			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "", "access_token_expiry": "2022-10-20T17:10:59.273429-04:00", "session_expiry": "2022-11-20T17:10:59.273429-04:00" }`),
 			expectedError: "failed to get cache refresh token",
 		},
 		{
 			name:          "emptyexpiry",
-			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "expiry": "", "max_age": 86400000000000 }`),
+			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "", "session_expiry": "2022-11-20T17:10:59.273429-04:00"}`),
 			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
 		},
 	}

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func TestWrite_NoDirectoryNoFile(t *testing.T) {
-
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 
@@ -54,7 +53,6 @@ func TestWrite_NoDirectoryNoFile(t *testing.T) {
 }
 
 func TestWrite_DirectoryExistsNoFile(t *testing.T) {
-
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 
@@ -97,7 +95,6 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 }
 
 func TestWrite_DirectoryExistsFileExists(t *testing.T) {
-
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 
@@ -114,7 +111,6 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 		RefreshToken: "SoRefreshing:)",
 		Expiry:       now,
 	}
-
 	assert.NoError(Write(tok))
 
 	tok2 := oauth2.Token{
@@ -122,7 +118,6 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 		RefreshToken: "StillSoRefreshing:)",
 		Expiry:       now,
 	}
-
 	assert.NoError(Write(tok2))
 
 	assert.DirExists(credentialDirectory)
@@ -148,7 +143,7 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	require.NoError(destroy())
 }
 
-func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
+func TestRead_InvalidFormat(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 
@@ -161,9 +156,6 @@ func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
 		fmt.Printf("not able to make test directory :%v", err)
 	}
 	require.NoError(err)
-
-	//initialize empty file with no contents
-	//create and initialize separate file that already has cache in it and that cache is overwritten rather than appended to
 
 	type redHerring struct {
 		AccessToken  string
@@ -179,29 +171,23 @@ func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
 
 	randomDataJSON, err := json.Marshal(randomData)
 
-	fmt.Printf("attempting to write to credentials file")
-
-	//manually write red herring struct to credentials file
 	err = os.WriteFile(credentialPath, randomDataJSON, directoryPermissions)
 	require.NoError(err)
 
-	fmt.Printf("wrote to credentials file")
-
-	//attempt to read bad form
 	_, err = Read()
 	require.Error(err)
 	assert.EqualError(err, "bad format: failed to get cache access token")
-
+	require.NoError(destroy())
 }
 
-func TestRead_DirectoryExistsFileExists(t *testing.T) {
+func TestRead_ValidFormat(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
 
 	credentialDirectory, _, err := setup()
 	require.NoError(err)
 	require.NotNil(credentialDirectory)
-	//write to file cache object
+
 	now := time.Now()
 	tok := oauth2.Token{
 		AccessToken:  "TopSecret!",
@@ -210,7 +196,7 @@ func TestRead_DirectoryExistsFileExists(t *testing.T) {
 	}
 
 	assert.NoError(Write(tok))
-	//read the cache object written earlier
+
 	cachePointer, err := Read()
 	require.NoError(err)
 
@@ -226,7 +212,6 @@ func TestRead_DirectoryExistsFileExists(t *testing.T) {
 	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cachePointer.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	assert.Equal(expectedCache.MaxAge.String(), cachePointer.MaxAge.String())
 	require.NoError(destroy())
-
 }
 
 func TestGetCredentialPaths_ReturnsPaths(t *testing.T) {
@@ -244,7 +229,6 @@ func TestGetCredentialPaths_ReturnsPaths(t *testing.T) {
 
 	assert.Equal(expectedDirectory, credentialDir)
 	assert.Equal(expectedPath, credentialPath)
-
 }
 
 func TestJsonToToken_BadJSONThrowsError(t *testing.T) {
@@ -289,7 +273,7 @@ func TestJsonToToken_BadJSONThrowsError(t *testing.T) {
 	}
 }
 
-func TestTokenToJson_BadFormThrowsError(t *testing.T) {
+func TestTokenToJson_BadJSONThrowsError(t *testing.T) {
 	testCases := []struct {
 		name          string
 		token         oauth2.Token
@@ -335,10 +319,8 @@ func TestTokenToJson_BadFormThrowsError(t *testing.T) {
 }
 
 func setup() (credentialDirectory, credentialPath string, err error) {
-
 	os.Setenv(envVarCacheTestMode, "true")
 
-	// TODO: replace with GetDirectory helper
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to retrieve test directory: %v", err)
@@ -355,10 +337,8 @@ func setup() (credentialDirectory, credentialPath string, err error) {
 }
 
 func destroy() error {
-
 	os.Unsetenv(envVarCacheTestMode)
 
-	// TODO: replace with GetDirectory helper
 	userHome, err := os.UserHomeDir()
 	if err != nil {
 		return fmt.Errorf("failed to retrieve test directory: %v", err)

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -33,13 +33,25 @@ func TestWrite_NoDirectoryNoFile(t *testing.T) {
 	assert.DirExists(credentialDirectory)
 	assert.FileExists(credentialPath)
 
-	// TODO: assert json matches our input token
 	rawJSON, err := os.ReadFile(credentialPath)
 
-	var tokFromJSON oauth2.Token
-	json.Unmarshal([]byte(rawJSON), tokFromJSON)
-	assert.Equal(tok, tokFromJSON)
+	var cacheFromJSON Cache
 
+	err = json.Unmarshal(rawJSON, &cacheFromJSON)
+	if err != nil {
+		fmt.Println("Failed to unmarshall JSON:", err)
+	}
+
+	expectedCache := Cache{
+		AccessToken:  tok.AccessToken,
+		RefreshToken: tok.RefreshToken,
+		Expiry:       tok.Expiry,
+		MaxAge:       MaxAge,
+	}
+	assert.Equal(expectedCache.AccessToken, cacheFromJSON.AccessToken)
+	assert.Equal(expectedCache.RefreshToken, cacheFromJSON.RefreshToken)
+	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
+	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
 	require.NoError(destroy())
 }
 

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -1,17 +1,83 @@
 package auth
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
+
+	assertpkg "github.com/stretchr/testify/assert"
+	requirepkg "github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
 func TestWrite_NoDirectoryNoFile(t *testing.T) {
 
+	require := requirepkg.New(t)
+	assert := assertpkg.New(t)
+
+	credentialDirectory, credentialPath, err := setup()
+	require.NoError(err)
+	require.NotNil(credentialDirectory)
+
+	now := time.Now()
+	tok := oauth2.Token{
+		AccessToken:  "TopSecret!",
+		RefreshToken: "SoRefreshing:)",
+		Expiry:       now,
+	}
+
+	assert.NoError(Write(tok))
+	assert.DirExists(credentialDirectory)
+	assert.FileExists(credentialPath)
+
+	// TODO: assert json matches our input token
+	rawJSON, err := os.ReadFile(credentialPath)
+
+	var tokFromJSON oauth2.Token
+	json.Unmarshal([]byte(rawJSON), tokFromJSON)
+	assert.Equal(tok, tokFromJSON)
+
+	require.NoError(destroy())
 }
 
-func setup() {
-	os.Setenv("HCP_CACHE_TEST_ENV", "true")
-	credentialDirectory := filepath.Join(auth.userHome, directoryName)
+func setup() (credentialDirectory, credentialPath string, err error) {
 
+	os.Setenv(envVarCacheTestMode, "true")
+
+	// TODO: replace with GetDirectory helper
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to retrieve test directory: %v", err)
+	}
+	credentialDirectory = filepath.Join(userHome, testDirectory)
+	credentialPath = filepath.Join(credentialDirectory, fileName)
+
+	err = os.RemoveAll(credentialDirectory)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to clean up test directory: %v", err)
+	}
+
+	return credentialDirectory, credentialPath, nil
+}
+
+func destroy() error {
+
+	os.Unsetenv(envVarCacheTestMode)
+
+	// TODO: replace with GetDirectory helper
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to retrieve test directory: %v", err)
+	}
+	credentialDirectory := filepath.Join(userHome, testDirectory)
+
+	err = os.RemoveAll(credentialDirectory)
+	if err != nil {
+		return fmt.Errorf("failed to clean up test directory: %v", err)
+	}
+
+	return nil
 }

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -1,0 +1,17 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWrite_NoDirectoryNoFile(t *testing.T) {
+
+}
+
+func setup() {
+	os.Setenv("HCP_CACHE_TEST_ENV", "true")
+	credentialDirectory := filepath.Join(auth.userHome, directoryName)
+
+}

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -227,6 +227,24 @@ func TestRead_DirectoryExistsFileExists(t *testing.T) {
 
 }
 
+func TestGetCredentialPaths_ReturnsPaths(t *testing.T) {
+	os.Setenv(envVarCacheTestMode, "true")
+
+	assert := assertpkg.New(t)
+
+	credentialPath, credentialDir, err := getCredentialPaths()
+
+	assert.NoError(err)
+
+	userHome, err := os.UserHomeDir()
+	expectedDirectory := filepath.Join(userHome, testDirectory)
+	expectedPath := filepath.Join(userHome, testDirectory, fileName)
+
+	assert.Equal(expectedDirectory, credentialDir)
+	assert.Equal(expectedPath, credentialPath)
+
+}
+
 func setup() (credentialDirectory, credentialPath string, err error) {
 
 	os.Setenv(envVarCacheTestMode, "true")

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -57,13 +57,12 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	// TODO Do we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 
 	credentialDirectory, credentialPath, err := setup()
 	require.NoError(err)
 	require.NotNil(credentialDirectory)
 
-	err = os.MkdirAll(testDirectory, 0755)
+	err = os.MkdirAll(testDirectory, directoryPermissions)
 	require.NoError(err)
 
 	now := time.Now()
@@ -101,16 +100,13 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	// TODO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 
 	credentialDirectory, credentialPath, err := setup()
 	require.NoError(err)
 	require.NotNil(credentialDirectory)
 
-	err = os.MkdirAll(testDirectory, 0755)
+	err = os.MkdirAll(testDirectory, directoryPermissions)
 	require.NoError(err)
-
-	// TODO Should we find a way to use WriteFile instead? It seems there are issues with it when in test mode
 
 	now := time.Now()
 	tok := oauth2.Token{
@@ -155,12 +151,11 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
 	require := requirepkg.New(t)
 
-	// DO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 	credentialDirectory, credentialPath, err := setup()
 	require.NoError(err)
 	require.NotNil(credentialDirectory)
 
-	err = os.MkdirAll(testDirectory, 0755)
+	err = os.MkdirAll(credentialDirectory, directoryPermissions)
 	if err != nil {
 		fmt.Printf("not able to make test directory :%v", err)
 	}
@@ -186,7 +181,7 @@ func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
 	fmt.Printf("attempting to write to credentials file")
 
 	//manually write red herring struct to credentials file
-	err = os.WriteFile(credentialPath, randomDataJSON, 0660)
+	err = os.WriteFile(credentialPath, randomDataJSON, directoryPermissions)
 	require.NoError(err)
 
 	fmt.Printf("wrote to credentials file")
@@ -200,7 +195,6 @@ func TestRead_DirectoryExistsFileExists_BadFormFailstoRead(t *testing.T) {
 func TestRead_DirectoryExistsFileExists(t *testing.T) {
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	// DO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 
 	credentialDirectory, _, err := setup()
 	require.NoError(err)

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -57,7 +57,7 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	// DO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
+	// TODO Do we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 
 	credentialDirectory, credentialPath, err := setup()
 	require.NoError(err)
@@ -95,14 +95,13 @@ func TestWrite_DirectoryExistsNoFile(t *testing.T) {
 	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
 	require.NoError(destroy())
-
 }
 
 func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 
 	require := requirepkg.New(t)
 	assert := assertpkg.New(t)
-	// DO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
+	// TODO we need 0755 permissions for directory, or is 0660 sufficient? Can we set read/write permissions as a constant?
 
 	credentialDirectory, credentialPath, err := setup()
 	require.NoError(err)
@@ -111,8 +110,7 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	err = os.MkdirAll(testDirectory, 0755)
 	require.NoError(err)
 
-	//initialize empty file with no contents
-	//create and initialize separate file that already has cache in it and that cache is overwritten rather than appended to
+	// TODO Should we find a way to use WriteFile instead? It seems there are issues with it when in test mode
 
 	now := time.Now()
 	tok := oauth2.Token{
@@ -122,6 +120,15 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	}
 
 	assert.NoError(Write(tok))
+
+	tok2 := oauth2.Token{
+		AccessToken:  "AnotherTopSecret!",
+		RefreshToken: "StillSoRefreshing:)",
+		Expiry:       now,
+	}
+
+	assert.NoError(Write(tok2))
+
 	assert.DirExists(credentialDirectory)
 	assert.FileExists(credentialPath)
 
@@ -133,9 +140,9 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	require.NoError(err)
 
 	expectedCache := Cache{
-		AccessToken:  tok.AccessToken,
-		RefreshToken: tok.RefreshToken,
-		Expiry:       tok.Expiry,
+		AccessToken:  tok2.AccessToken,
+		RefreshToken: tok2.RefreshToken,
+		Expiry:       tok2.Expiry,
 		MaxAge:       MaxAge,
 	}
 	assert.Equal(expectedCache.AccessToken, cacheFromJSON.AccessToken)
@@ -143,7 +150,6 @@ func TestWrite_DirectoryExistsFileExists(t *testing.T) {
 	assert.Equal(expectedCache.Expiry.Format("2006-01-02T15:04:05 -07:00:00"), cacheFromJSON.Expiry.Format("2006-01-02T15:04:05 -07:00:00"))
 	assert.Equal(expectedCache.MaxAge.String(), cacheFromJSON.MaxAge.String())
 	require.NoError(destroy())
-
 }
 
 func setup() (credentialDirectory, credentialPath string, err error) {


### PR DESCRIPTION
### :hammer_and_wrench: Description

Adds a new library that can write and read OAuth2 tokens to a user's local machine.

### :link: External Links


### :ship: Release Note
Release note for [CHANGELOG](https://github.com/hashicorp/hcp-sdk-go/blob/main/CHANGELOG.md):

```release-note
Add a new set of functions that can write and read oauth2 tokens to disk
```

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?