### PR TITLE
HCE-556 Cleanup Auto Release

### DIFF
--- a/.changelog/130.txt
+++ b/.changelog/130.txt
@@ -1,0 +1,7 @@
+```release-note:improvement
+Remove redundant caching in Release Workflow
+```
+
+```release-note:improvement
+Add reminder to add changelog entry in PR template
+```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->
+
 ### :hammer_and_wrench: Description
 
 <!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           cache: true
           go-version-file: 'go.mod'
+          cache-dependency-path: go.sum
 
       - name: Configure Git
         env:
@@ -33,16 +34,6 @@ jobs:
             git config --global url."https://${TOKEN}:x-oauth-basic@github.com/".insteadOf "https://github.com/"
             git config user.name "hashicorp-cloud"
             git config user.email "hashicorp-cloud@hashicorp.com"
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Install Go Binaries
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,16 +17,7 @@ jobs:
         with:
           cache: true
           go-version-file: 'go.mod'
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          cache-dependency-path: go.sum
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
### :hammer_and_wrench: Description

Cleanup some loose ends on the auto release functionality. Namely remove the redundant cache since `setup-go` can do that for us as well as add a comment in the PR Template that reminds users to create a changelog entry.
