### PR TITLE
HCE-606: enable browser login test

### DIFF
--- a/.changelog/135.txt
+++ b/.changelog/135.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Skip browser login test during CI.
+```

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ go/lint:
 # Run the test and generate an html coverage file.
 .PHONY: test-ci
 test-ci: go/lint
-	go test -coverprofile=coverage.out ./...
+	go test -coverprofile=coverage.out -short ./...
 	go tool cover -html=coverage.out -o coverage.html
 
 # args passed to sdk/update

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -119,20 +119,23 @@ func TestNew_Invalid(t *testing.T) {
 	}
 }
 
-// TODO: uncomment these tests when we've set up a CI test user to login via browser (HCE-606)
-// func TestNew_NoConfigPassed(t *testing.T) {
-// 	require := requirepkg.New(t)
+// This test will open your default browser and ask you to login with HCP.
+func TestNew_NoConfigPassed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode (CI).")
+	}
+	require := requirepkg.New(t)
 
-// 	// Exercise
-// 	config, err := NewHCPConfig()
-// 	require.NoError(err)
+	// Exercise
+	config, err := NewHCPConfig()
+	require.NoError(err)
 
-// 	// Ensure the values have been set accordingly
-// 	token, err := config.Token()
-// 	require.NoError(err)
-// 	require.NotNil(token)
+	// Ensure the values have been set accordingly
+	token, err := config.Token()
+	require.NoError(err)
+	require.NotNil(token)
 
-// 	require.Equal(defaultPortalURL, config.PortalURL().String())
-// 	require.Equal(defaultAPIAddress, config.APIAddress())
-// 	require.Equal(defaultSCADAAddress, config.SCADAAddress())
-// }
+	require.Equal(defaultPortalURL, config.PortalURL().String())
+	require.Equal(defaultAPIAddress, config.APIAddress())
+	require.Equal(defaultSCADAAddress, config.SCADAAddress())
+}


### PR DESCRIPTION
### :hammer_and_wrench: Description

This PR skips the test that pops up the browser login, since there is no straightforward way to automatically enter user credentials into the test browser. Instead, this test should be run locally with using the developer's user credentials to login.