### PR TITLE
transform-swagger: fix GoogleRPCStatus case

### DIFF
--- a/.changelog/138.txt
+++ b/.changelog/138.txt
@@ -1,0 +1,3 @@
+```release-note:BUG
+Added exception for google.rpc.status when generating code since it was mistakenly rendered as `GoogleRpcStatus` instead of `GoogleRPCStatus`
+```


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

When updating cloud-packer-service to grpc-gateway v2, we broke the generated SDK for the service because the error type for all our API calls was changed from #/definitions/grpc.gateway.runtime.Error to \#/definitions/google.rpc.Status.

This change then conflicted with the transform-swagger code, as it would invoke `toCamel` on it, rendering the generated type as `*cloud.GoogleRpcStatus`, where the real type is
`*cloud.GoogleRPCStatus`.

To circumvent this problem, we hard-code this special case in the transform command, so we end-up with the expected type in the generated Go code.

<!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 
version of a service SDK was added, what are the key new features or breaking changes? -->

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?