### PR TITLE
Retract v0.26.0

### DIFF
--- a/.changelog/139.txt
+++ b/.changelog/139.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Remove v0.26.0 from pkg.go.dev
+```

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/hashicorp/hcp-sdk-go
 
 go 1.18
 
-retract v0.26.0
+retract v0.26.0 // Pushed accidentally
 
 require (
 	github.com/go-openapi/errors v0.20.3

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/hashicorp/hcp-sdk-go
 
 go 1.18
 
+retract v0.26.0
+
 require (
 	github.com/go-openapi/errors v0.20.3
 	github.com/go-openapi/loads v0.20.2


### PR DESCRIPTION
### :hammer_and_wrench: Description

Retract v0.26.0 from public release since we have created it erroneously.