### PR TITLE
changelog: add note on next breaking update

### DIFF
--- a/.changelog/140.txt
+++ b/.changelog/140.txt
@@ -1,0 +1,5 @@
+```release-note:breaking-change
+The cloud-packer service was updated to grpc_gateway v2, this changes the payloads for the requests in some routes, as they are now embedded within the request rather than referenced from it.
+For example, the body for UpdateBucket was previously a *models.HashicorpCloudPackerUpdateBucketRequest, now it is a packer_service.PackerServiceUpdateBucketBody.
+Some attributes which were duplicated in the body now are only in the parent structure, for example &models.HashicorpCloudPackerUpdateBucketRequest used to contain BucketSlug, already present in the parent structure, this is not the case anymore.
+```


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

The HCP Packer API was updated to grpc_gateway v2, which induces a breaking change in the payloads for the requests on some routes as the body is now inlined in the definition rather than a reference to a component.

<!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 
version of a service SDK was added, what are the key new features or breaking changes? -->

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?