### PR TITLE
Update config session to implement pointer instance

### DIFF
--- a/.changelog/141.txt
+++ b/.changelog/141.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Allow session information to be stored as pointer
+```

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -88,7 +88,7 @@ type hcpConfig struct {
 
 	// session is responsible for getting an access token fron our identity provider.
 	// A mock can be used in tests.
-	session auth.Session
+	session *auth.Session
 
 	// profile is the user's organization id and project id
 	profile *profile.UserProfile

--- a/config/new.go
+++ b/config/new.go
@@ -58,6 +58,8 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 	portalURL, _ := url.Parse(defaultPortalURL)
 
 	// Prepare basic config with default values.
+	var sessionInstance auth.Session
+	sessionInstance = &auth.UserSession{}
 	config := &hcpConfig{
 		clientCredentialsConfig: clientcredentials.Config{
 			EndpointParams: url.Values{"audience": {aud}},
@@ -74,7 +76,7 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 			RedirectURL: "http://localhost:8443/oidc/callback",
 			Scopes:      []string{"openid", "offline_access"},
 		},
-		session: &auth.UserSession{},
+		session: &sessionInstance,
 		profile: &profile.UserProfile{},
 
 		portalURL: portalURL,
@@ -113,8 +115,7 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 		config.tokenSource = config.clientCredentialsConfig.TokenSource(tokenContext)
 
 	} else { // Set access token via browser login or use token from existing session.
-
-		tok, err := config.session.GetToken(tokenContext, &config.oauth2Config)
+		tok, err := (*config.session).GetToken(tokenContext, &config.oauth2Config)
 		if err != nil {
 			return nil, fmt.Errorf("failed to find existing session or set up new: %w", err)
 		}

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -53,8 +53,10 @@ func TestNew_MockSession(t *testing.T) {
 	require := requirepkg.New(t)
 
 	// Exercise
+	var mock auth.Session
+	mock = &auth.MockSession{}
 	config, err := NewHCPConfig(
-		WithSession(&auth.MockSession{}),
+		WithSession(&mock),
 	)
 
 	require.NoError(err)

--- a/config/with.go
+++ b/config/with.go
@@ -119,7 +119,7 @@ func WithOAuth2ClientID(oauth2ClientID string) HCPConfigOption {
 // will be used.
 //
 // This should only be necessary for testing purposes.
-func WithSession(s auth.Session) HCPConfigOption {
+func WithSession(s *auth.Session) HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.session = s
 

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -106,7 +106,7 @@ func TestWith_Session(t *testing.T) {
 	require.NoError(apply(config, WithSession(&mock)))
 
 	// Ensure Sessions is an empty MockSession object
-	require.Equal(&auth.MockSession{}, config.session)
+	require.EqualValues(config.session, &auth.MockSession{})
 }
 
 func TestWith_Profile(t *testing.T) {

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -100,8 +100,10 @@ func TestWith_Session(t *testing.T) {
 	require := requirepkg.New(t)
 
 	// Exercise
+	var mock auth.Session
+	mock = &auth.MockSession{}
 	config := &hcpConfig{}
-	require.NoError(apply(config, WithSession(&auth.MockSession{})))
+	require.NoError(apply(config, WithSession(&mock)))
 
 	// Ensure Sessions is an empty MockSession object
 	require.Equal(&auth.MockSession{}, config.session)


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

This PR includes HCP config updates to enable use of a session instance pointer, rather than a session object. This change protects against a user's session being overridden as fields are accessed or updated.

### :link: External Links

HCE-273 - [Session Refresh](https://hashicorp.atlassian.net/browse/HCE-273)

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?