### PR TITLE
Insert middleware to allow org and prod id on requests

### DIFF
--- a/.changelog/142.txt
+++ b/.changelog/142.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Insert middleware to allow organization and project id on requests 
+```

--- a/.changelog/142.txt
+++ b/.changelog/142.txt
@@ -1,5 +1,5 @@
 ```release-note:improvement
-Add middleware package
+Add middleware support to httpclient package
 ```
 
 ```release-note:improvement

--- a/.changelog/142.txt
+++ b/.changelog/142.txt
@@ -1,3 +1,7 @@
 ```release-note:improvement
-Insert middleware to allow organization and project id on requests 
+Add middleware package
+```
+
+```release-note:improvement
+Add middleware that gets org ID and project ID from user profile and sets on request
 ```

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -138,6 +138,12 @@ func (c *hcpConfig) validate() error {
 		return fmt.Errorf("either client credentials or oauth2 client ID must be provided")
 	}
 
+	// Ensure profile contains both org ID and project ID
+	if (c.profile.OrganizationID == "" && c.profile.ProjectID != "") ||
+		(c.profile.OrganizationID != "" && c.profile.ProjectID == "") {
+		return fmt.Errorf("when setting a user profile, both organization ID and project ID must be provided")
+	}
+
 	// Ensure the auth URL is valid
 	if c.authURL.Host == "" {
 		return fmt.Errorf("the auth URL has to be non-empty")

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -111,6 +111,26 @@ func TestNew_Invalid(t *testing.T) {
 			},
 			expectedError: "the configuration is not valid: the SCADA address has to be non-empty",
 		},
+		{
+			name: "empty project ID with populated org ID",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithProfile(&profile.UserProfile{
+					OrganizationID: "abc123",
+				}),
+			},
+			expectedError: "the configuration is not valid: when setting a user profile, both organization ID and project ID must be provided",
+		},
+		{
+			name: "empty org ID with populated project ID",
+			options: []HCPConfigOption{
+				WithClientCredentials("my-client-id", "my-client-secret"),
+				WithProfile(&profile.UserProfile{
+					ProjectID: "abc123",
+				}),
+			},
+			expectedError: "the configuration is not valid: when setting a user profile, both organization ID and project ID must be provided",
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -68,13 +68,12 @@ type roundTripperWithProfile struct {
 }
 
 func (rt *roundTripperWithProfile) RoundTrip(req *http.Request) (*http.Response, error) {
-	fmt.Printf("REQUEST URL BEFORE: %v", req.URL.Path)
-	url := req.URL.Path
-	strings.Replace(url, "organizations//", fmt.Sprintf("organizations/%s/", rt.OrganizationID), 1)
-	strings.Replace(url, "projects//", fmt.Sprintf("projects/%s/", rt.ProjectID), 1)
+	path := req.URL.Path
+	path = strings.Replace(path, "organizations//", fmt.Sprintf("organizations/%s/", rt.OrganizationID), 1)
+	path = strings.Replace(path, "projects//", fmt.Sprintf("projects/%s/", rt.ProjectID), 1)
+	req.URL.Path = path
+
 	// TODO check that source channel didn't get overwritten
-	req.URL.Path = url
-	fmt.Printf("REQUEST URL AFTER: %v", req.URL.Path)
 	return rt.OriginalRoundTripper.RoundTrip(req)
 }
 

--- a/httpclient/httpclient.go
+++ b/httpclient/httpclient.go
@@ -80,7 +80,7 @@ func New(cfg Config) (runtime *httptransport.Runtime, err error) {
 
 	if cfg.Profile().OrganizationID != "" && cfg.Profile().ProjectID != "" {
 
-		opts = append(opts, withProfile(cfg.Profile().OrganizationID, cfg.Profile().ProjectID))
+		opts = append(opts, withOrgAndProjectIDs(cfg.Profile().OrganizationID, cfg.Profile().ProjectID))
 	}
 
 	transport = &roundTripperWithMiddleware{

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -182,7 +182,7 @@ func TestMiddleware(t *testing.T) {
 	assert.NotContains(t, request.URL.Path, expectedProjID)
 
 	// Prepare middleware function.
-	profileMiddleware := withProfile(expectedOrgID, expectedProjID)
+	profileMiddleware := withOrgAndProjectIDs(expectedOrgID, expectedProjID)
 
 	// Apply middleware function.
 	err = profileMiddleware(request)

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -155,7 +155,7 @@ func TestNew(t *testing.T) {
 
 }
 
-//Must have integration environment set and client credentials
+// Must have integration environment set and client credentials
 func TestProfileIntegration(t *testing.T) {
 	// Create a config that calls the test server
 

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -163,6 +163,7 @@ func TestProfileIntegration(t *testing.T) {
 		config.WithClientCredentials(os.Getenv("HCP_CLIENT_ID"), os.Getenv("HCP_CLIENT_SECRET")),
 		config.WithProfile(&profile.UserProfile{OrganizationID: os.Getenv("HCP_ORGANIZATION_ID"), ProjectID: os.Getenv("HCP_PROJECT_ID")}),
 	)
+	require.NoError(t, err)
 
 	cl, err := New(Config{
 		HCPConfig: hcpConfig,

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -157,8 +157,11 @@ func TestNew(t *testing.T) {
 
 // Defaults to production environment and client credentials
 func TestProfileIntegration(t *testing.T) {
-	// Create a config that calls the test server
+	if testing.Short() {
+		t.Skip("skipping test in short mode (CI).")
+	}
 
+	// Create a config that calls the test server
 	hcpConfig, err := config.NewHCPConfig(
 		config.WithClientCredentials(os.Getenv("HCP_CLIENT_ID"), os.Getenv("HCP_CLIENT_SECRET")),
 		config.WithProfile(&profile.UserProfile{OrganizationID: os.Getenv("HCP_ORGANIZATION_ID"), ProjectID: os.Getenv("HCP_PROJECT_ID")}),

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -105,39 +105,6 @@ func TestNew(t *testing.T) {
 		require.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
 	})
 
-	t.Run("legacy configuration, no source channel", func(t *testing.T) {
-		numRequests = 0
-
-		cfg := Config{
-			HostPath:     ts.URL,
-			AuthURL:      ts.URL,
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			// Override the base http.Client so that we trust the test server's TLS
-			Client: ts.Client(),
-		}
-
-		// The test's important assertions occur in the test server handler above.
-		// When an http client is initialized, it tries to obtain an access token using the configured token URL (from an auth provider), client ID, and client secret.
-		// The token request embedded in this client initializer hits the mock auth provider handler above ('/oauth/token').
-		cl, err := New(cfg)
-		require.NoError(t, err)
-
-		consulClient := consul.New(cl, nil)
-		listParams := consul.NewListParams()
-		listParams.LocationOrganizationID = orgID
-		listParams.LocationProjectID = projID
-
-		// This SDK request hits the mock Consul List API handler above ('/consul/2021-02-04/organizations...').
-		// The handler verifies that the expected bearer token is provided.
-		_, err = consulClient.List(listParams, nil)
-		require.NoError(t, err)
-
-		// Make sure we actually handled both the auth and the GET request and didn't
-		// just skip all the assertions!
-		require.Equal(t, uint32(2), atomic.LoadUint32(&numRequests))
-	})
-
 	t.Run("HCPConfig", func(t *testing.T) {
 		numRequests = 0
 

--- a/httpclient/httpclient_test.go
+++ b/httpclient/httpclient_test.go
@@ -155,21 +155,20 @@ func TestNew(t *testing.T) {
 
 }
 
-// Must have integration environment set and client credentials
+// Defaults to production environment and client credentials
 func TestProfileIntegration(t *testing.T) {
 	// Create a config that calls the test server
 
 	hcpConfig, err := config.NewHCPConfig(
 		config.WithClientCredentials(os.Getenv("HCP_CLIENT_ID"), os.Getenv("HCP_CLIENT_SECRET")),
 		config.WithProfile(&profile.UserProfile{OrganizationID: os.Getenv("HCP_ORGANIZATION_ID"), ProjectID: os.Getenv("HCP_PROJECT_ID")}),
-		config.WithAuth(os.Getenv("HCP_AUTH_URL"), nil),
-		config.WithAPI(os.Getenv("HCP_API_HOST"), nil),
 	)
 
 	cl, err := New(Config{
 		HCPConfig: hcpConfig,
 	})
 	require.NoError(t, err)
+
 	consulClient := consul.New(cl, nil)
 	listParams := consul.NewListParams()
 	_, err = consulClient.List(listParams, nil)

--- a/httpclient/middleware.go
+++ b/httpclient/middleware.go
@@ -24,7 +24,7 @@ func withSourceChannel(sourceChannel string) MiddlewareOption {
 }
 
 // withProfile takes the user profile's org ID and project ID and sets them in the request path if needed.
-func withProfile(orgID, projID string) MiddlewareOption {
+func withOrgAndProjectIDs(orgID, projID string) MiddlewareOption {
 	return func(req *http.Request) error {
 		path := req.URL.Path
 		path = strings.Replace(path, "organizations//", fmt.Sprintf("organizations/%s/", orgID), 1)

--- a/httpclient/middleware.go
+++ b/httpclient/middleware.go
@@ -1,0 +1,49 @@
+package httpclient
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// MiddlewareOption is a function that modifies an HTTP request.
+type MiddlewareOption = func(req *http.Request) error
+
+// roundTripperWithMiddleware takes a plain Roundtripper and an array of MiddlewareOptions to apply to the Roundtripper's request.
+type roundTripperWithMiddleware struct {
+	OriginalRoundTripper http.RoundTripper
+	MiddlewareOptions    []MiddlewareOption
+}
+
+// withSourceChannel updates the request header to include the HCP Go SDK source channel stamp.
+func withSourceChannel(sourceChannel string) MiddlewareOption {
+	return func(req *http.Request) error {
+		req.Header.Set("X-HCP-Source-Channel", sourceChannel)
+		return nil
+	}
+}
+
+// withProfile takes the user profile's org ID and project ID and sets them in the request path if needed.
+func withProfile(orgID, projID string) MiddlewareOption {
+	return func(req *http.Request) error {
+		path := req.URL.Path
+		path = strings.Replace(path, "organizations//", fmt.Sprintf("organizations/%s/", orgID), 1)
+		path = strings.Replace(path, "projects//", fmt.Sprintf("projects/%s/", projID), 1)
+		req.URL.Path = path
+		return nil
+	}
+}
+
+// RoundTrip attaches MiddlewareOption modifications to the request before sending along.
+func (rt *roundTripperWithMiddleware) RoundTrip(req *http.Request) (*http.Response, error) {
+
+	for _, mw := range rt.MiddlewareOptions {
+		if err := mw(req); err != nil {
+			// Failure to apply middleware should not fail the request
+			fmt.Printf("failed to apply middleware: %#v", mw(req))
+			continue
+		}
+	}
+
+	return rt.OriginalRoundTripper.RoundTrip(req)
+}


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

These code changes include added middleware to allow organization and project id collected from a user's profile to attach to client requests.

### :link: External Links

HCE-652 : [Middleware package that injects the saved project ID/org ID into every SDK request](https://hashicorp.atlassian.net/browse/HCE-652)

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?