### PR TITLE
HCE-742: Remove create-pull-request Third Party Action

### DIFF
--- a/.changelog/152.txt
+++ b/.changelog/152.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Remove `create-pull-request` third party action in favour of plain git commands.
+```

--- a/.github/workflows/publish-shared-sdk.yml
+++ b/.github/workflows/publish-shared-sdk.yml
@@ -52,12 +52,12 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/hcp-sdk-go
           git config user.name "HashiCorp Cloud Services"
-          git config user.email "59096967+hashicorp-cloud@users.noreply.github.com"
+          git config user.email "${{ secrets.HCP_SERVICE_ACCOUNT_EMAIL }}"
           service_branch_exists="$(git ls-remote --heads origin auto-update-cloud-shared-sdk)"
           [[ -n $service_branch_exists ]] && git push origin --delete auto-update-cloud-shared-sdk
           git checkout -b auto-update-cloud-shared-sdk
           git add clients/cloud-shared/*
-          git commit -m "Update Cloud API SDK"
+          git commit -m "Update cloud-shared SDK"
           git push --set-upstream origin auto-update-cloud-shared-sdk    
           
       - name: Open PR
@@ -66,7 +66,7 @@ jobs:
           gh pr create --title "$PR_TITLE" --body "$PR_BODY" -H "$PR_SOURCE" -B "$PR_TARGET"
         env:
           PR_TITLE: "[auto] Update Shared SDK"
-          PR_BODY: "This is an auto-generated PR created as part of the public SDK pipeline to update Cloud API."
+          PR_BODY: "This is an auto-generated PR created as part of the public SDK pipeline to update cloud-shared clients."
           PR_SOURCE: "auto-update-cloud-shared-sdk"
           PR_TARGET: "main"
           GITHUB_TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }} 

--- a/.github/workflows/publish-shared-sdk.yml
+++ b/.github/workflows/publish-shared-sdk.yml
@@ -48,25 +48,25 @@ jobs:
           ./scripts/gen-go-shared-sdk.sh
           rm -rf $GITHUB_WORKSPACE/hcp-sdk-go/temp
 
+      - name: Create branch with updated service SDK
+        run: |
+          cd $GITHUB_WORKSPACE/hcp-sdk-go
+          git config user.name "HashiCorp Cloud Services"
+          git config user.email "59096967+hashicorp-cloud@users.noreply.github.com"
+          service_branch_exists="$(git ls-remote --heads origin auto-update-cloud-shared-sdk)"
+          [[ -n $service_branch_exists ]] && git push origin --delete auto-update-cloud-shared-sdk
+          git checkout -b auto-update-cloud-shared-sdk
+          git add clients/cloud-shared/*
+          git commit -m "Update Cloud API SDK"
+          git push --set-upstream origin auto-update-cloud-shared-sdk    
+          
       - name: Open PR
-        id: pr
-        uses: peter-evans/create-pull-request@v3.10.1
-        with:
-          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
-          path: hcp-sdk-go
-          branch: auto-update-shared-sdk
-          committer: HashiCorp Cloud Services <59096967+hashicorp-cloud@users.noreply.github.com>
-          commit-message: Update cloud-shared SDK 
-          title: '[auto] Update cloud-shared SDK' 
-          body: |
-            This is an auto-generated PR created as part of the public SDK pipeline.
-
-            Changes:
-            - Pulled the latest public service SDK from cloud-shared
-          delete-branch: true
-
-      # The Open PR action won't fail if no PR is opened, so this step verifies that a PR was actually created.
-      - name: Verify PR created
-        run:  |
-          pr="${{ steps.pr.outputs.pull-request-url }}"
-          [[ ! -z "$pr" ]] && echo "Pull Request URL - $pr" || exit 1
+        run: |
+          cd $GITHUB_WORKSPACE/hcp-sdk-go
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" -H "$PR_SOURCE" -B "$PR_TARGET"
+        env:
+          PR_TITLE: "[auto] Update Shared SDK"
+          PR_BODY: "This is an auto-generated PR created as part of the public SDK pipeline to update Cloud API."
+          PR_SOURCE: "auto-update-cloud-shared-sdk"
+          PR_TARGET: "main"
+          GITHUB_TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }} 


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

Removes the `create-pull-request` third party action and follows what was done in the `publish-sdk.yml` workflow.