### PR TITLE
HCE-24: Sync Internal and Public SDK Repos Automatically

### DIFF
--- a/.changelog/157.txt
+++ b/.changelog/157.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+Automatically sync the public and internal repos.
+```

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,6 @@
 name: Sync Internal and Public Repos
 
-on: workflow_dispatch
+on: pull_request
 
 jobs:
   sync-repos:

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,0 +1,29 @@
+name: Sync Internal and Public Repos
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sync-repos:
+    name: Sync Internal and Public Repos
+    steps:
+      - name: Checkout Public Repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+          path: public
+
+      - name: Checkout Internal Repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+          repository: hashicorp/hcp-sdk-go-internal
+          path: internal
+
+      - name: Test Checkouts
+        run: |
+          ls
+          cd ..
+          ls
+

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,7 +1,6 @@
 name: Sync Internal and Public Repos
 
 on:
-  pull_request:
   workflow_dispatch:
   workflow_run:
     workflows: ["Create Release"]

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,11 @@
 name: Sync Internal and Public Repos
 
-on: pull_request
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Create Release"]
+    types:
+      - completed
 
 jobs:
   sync-repos:

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,7 @@
 name: Sync Internal and Public Repos
 
 on:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -36,7 +36,7 @@ jobs:
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp internal/README.md temp/README.md
-          cp internal/catalog-info.yml temp/catalog-info.yml
+          cp internal/catalog-info.yaml temp/catalog-info.yaml
           cp internal/mkdocs.yml temp/mkdocs.yml
 
           rm -r internal

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,7 +1,6 @@
 name: Sync Internal and Public Repos
 
-on:
-  workflow_dispatch:
+on: workflow_dispatch
 
 jobs:
   sync-repos:

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -31,14 +31,14 @@ jobs:
           ls -al public
           
           # Copy important files from internal repo
-          cp -a internal/.git temp/.git
+          sudo cp -a internal/.git temp/.git
           cp -a internal/.github temp/.github
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp internal/README.md temp/README.md
 
           cp -a public/. internal
-          cp -a temp/. internal
+          sudo cp -a temp/. internal
 
           cd internal
           git status

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -36,6 +36,8 @@ jobs:
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp internal/README.md temp/README.md
+          cp internal/catalog.yml temp/catalog.yml
+          cp internal/mkdocs.yml temp/mkdocs.yml
 
           rm -r internal
           mkdir internal

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -36,7 +36,7 @@ jobs:
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp internal/README.md temp/README.md
-          cp internal/catalog.yml temp/catalog.yml
+          cp internal/catalog-info.yml temp/catalog-info.yml
           cp internal/mkdocs.yml temp/mkdocs.yml
 
           rm -r internal

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,6 @@
 name: Sync Internal and Public Repos
 
-on: pull_request
+on: workflow_dispatch
 
 jobs:
   sync-repos:

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,6 @@
 name: Sync Internal and Public Repos
 
-on: workflow_dispatch
+on: pull_request
 
 jobs:
   sync-repos:
@@ -27,7 +27,7 @@ jobs:
           mkdir temp
 
           # Remove files from public repo
-          rm -r public/.git public/.github public/.changelog public/clients public/docs public/README.md
+          rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md
           ls -al public
           
           # Copy important files from internal repo
@@ -37,6 +37,10 @@ jobs:
           cp -a internal/docs temp/docs
           cp internal/README.md temp/README.md
 
+          rm -r internal
+          mkdir internal
+
+          # Sync public with internal
           cp -a public/. internal
           sudo cp -a temp/. internal
 

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -44,7 +44,6 @@ jobs:
           cp internal/README.md temp/README.md
           cp internal/catalog-info.yaml temp/catalog-info.yaml
           cp internal/mkdocs.yml temp/mkdocs.yml
-          cp internal/scripts/gen-go-service-sdk.sh temp/scripts/gen-go-service-sdk.sh
 
           rm -r internal
           mkdir internal

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -35,7 +35,7 @@ jobs:
           rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md public/scripts
           ls -al public
           
-          # Copy important files from internal repo
+          # Copy files that should not be changed in internal repo
           sudo cp -a internal/.git temp/.git
           cp -a internal/.github temp/.github
           cp -a internal/clients temp/clients

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,7 @@
 name: Sync Internal and Public Repos
 
 on:
+  pull_request:
   workflow_dispatch:
   workflow_run:
     workflows: ["Create Release"]
@@ -32,7 +33,7 @@ jobs:
           mkdir temp
 
           # Remove files from public repo
-          rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md public/scripts/gen-go-service-sdk.sh
+          rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md public/scripts
           ls -al public
           
           # Copy important files from internal repo
@@ -40,6 +41,7 @@ jobs:
           cp -a internal/.github temp/.github
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
+          cp -a internal/scripts temp/scripts
           cp internal/README.md temp/README.md
           cp internal/catalog-info.yaml temp/catalog-info.yaml
           cp internal/mkdocs.yml temp/mkdocs.yml

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -51,7 +51,7 @@ jobs:
           sync_branch_exists="$(git ls-remote --heads origin sync-public-and-internal-sdk)"
           [[ -n $sync_branch_exists ]] && git push origin --delete sync-public-and-internal-sdk
           git checkout -b sync-public-and-internal-sdk
-          git add -a
+          git add -A
           git commit -m "Sync with public SDK"
           git push --set-upstream origin sync-public-and-internal-sdk
       

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,7 +1,6 @@
 name: Sync Internal and Public Repos
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -9,6 +8,13 @@ jobs:
     name: Sync Internal and Public Repos
     runs-on: ubuntu-latest
     steps:
+      - name: Configure Git
+        env:
+          TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
+        run: |
+            git config user.name "hashicorp-cloud"
+            git config user.email "hashicorp-cloud@hashicorp.com"
+
       - name: Checkout Public Repo
         uses: actions/checkout@v3
         with:
@@ -23,12 +29,45 @@ jobs:
           repository: hashicorp/hcp-sdk-go-internal
           path: internal
 
-      - name: Test Checkouts
+      - name: Sync Changes
         run: |
-          echo "-- Current Directory"
-          ls
-          echo "-- Change Directory Out"
-          cd ..
-          echo "-- List"
-          ls
+          # Make a temp directory for the internal repo
+          mkdir temp
 
+          # Remove files from public repo
+          rm -r public/.git public/.github public/.changelog public/clients public/docs public/README.md
+          ls -al public
+          
+          # Copy important files from internal repo
+          cp -a internal/.git temp/.git
+          cp -a internal/.github temp/.github
+          cp -a internal/clients temp/clients
+          cp -a internal/docs temp/docs
+          cp internal/README.md temp/README.md
+
+          cp -a public/. internal
+          cp -a temp/. internal
+
+          cd internal
+          git status
+
+      - name: Create Branch
+        run: |
+          cd internal
+          sync_branch_exists="$(git ls-remote --heads origin sync-public-and-internal-sdk)"
+          [[ -n $sync_branch_exists ]] && git push origin --delete sync-public-and-internal-sdk
+          git checkout -b sync-public-and-internal-sdk
+          git add -a
+          git commit -m "Sync with public SDK"
+          git push --set-upstream origin sync-public-and-internal-sdk
+      
+      - name: Open PR
+        run: |
+          cd internal
+          gh pr create --title "$PR_TITLE" --body "$PR_BODY" -H "$PR_SOURCE" -B "$PR_TARGET"
+        env:
+          PR_TITLE: "[auto] Sync with Public SDK"
+          PR_BODY: "This is an auto-generated PR created as part of the public SDK pipeline to update the internal SDK."
+          PR_SOURCE: "sync-public-and-internal-sdk"
+          PR_TARGET: "main"
+          GITHUB_TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -7,13 +7,6 @@ jobs:
     name: Sync Internal and Public Repos
     runs-on: ubuntu-latest
     steps:
-      - name: Configure Git
-        env:
-          TOKEN: ${{ secrets.HCP_SDK_PIPELINE_TOKEN }}
-        run: |
-            git config user.name "hashicorp-cloud"
-            git config user.email "hashicorp-cloud@hashicorp.com"
-
       - name: Checkout Public Repo
         uses: actions/checkout@v3
         with:
@@ -53,6 +46,8 @@ jobs:
       - name: Create Branch
         run: |
           cd internal
+          git config user.name "HashiCorp Cloud Services"
+          git config user.email "${{ secrets.HCP_SERVICE_ACCOUNT_EMAIL }}"
           sync_branch_exists="$(git ls-remote --heads origin sync-public-and-internal-sdk)"
           [[ -n $sync_branch_exists ]] && git push origin --delete sync-public-and-internal-sdk
           git checkout -b sync-public-and-internal-sdk

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -25,7 +25,10 @@ jobs:
 
       - name: Test Checkouts
         run: |
+          echo "-- Current Directory"
           ls
+          echo "-- Change Directory Out"
           cd ..
+          echo "-- List"
           ls
 

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -1,6 +1,7 @@
 name: Sync Internal and Public Repos
 
 on:
+  pull_request:
   workflow_dispatch:
   workflow_run:
     workflows: ["Create Release"]
@@ -32,7 +33,7 @@ jobs:
           mkdir temp
 
           # Remove files from public repo
-          rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md
+          rm -r public/.git public/.changelog public/.github public/clients public/docs public/README.md public/scripts/gen-go-service-sdk.sh
           ls -al public
           
           # Copy important files from internal repo
@@ -43,6 +44,7 @@ jobs:
           cp internal/README.md temp/README.md
           cp internal/catalog-info.yaml temp/catalog-info.yaml
           cp internal/mkdocs.yml temp/mkdocs.yml
+          cp internal/scripts/gen-go-service-sdk.sh temp/scripts/gen-go-service-sdk.sh
 
           rm -r internal
           mkdir internal

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   sync-repos:
     name: Sync Internal and Public Repos
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Public Repo
         uses: actions/checkout@v3


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add a workflow that will sync this repo with the internal counterpart after each automated releases. This also makes the workflow available as a dispatch.

Resulting PR: https://github.com/hashicorp/hcp-sdk-go-internal/pull/19