### PR TITLE
Update action go version to read from go mod

### DIFF
--- a/.changelog/161.txt
+++ b/.changelog/161.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Update action to read go version from repo go.mod
+```

--- a/.github/workflows/publish-sdk.yml
+++ b/.github/workflows/publish-sdk.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.16.0'
+          go-version-file: 'go.mod'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
### :hammer_and_wrench: Description

This code change includes a small action update to select the go version based on the contents of go.mod. This resolves a bug where the action updating a repo's specs may misalign with the repo's go version and cause dependency conflicts.

### :link: External Links

HCE-796 - [SDK Generation Update](https://hashicorp.atlassian.net/browse/HCE-796)
Example Dependabot PR requiring dependency change - [Bump open-api/runtime](https://github.com/hashicorp/hcp-sdk-go/pull/148)
Github action citing mismatched dependency as cause for SDK generation failure - [Update-sdk](https://github.com/hashicorp/hcp-sdk-go-internal/actions/runs/3969232356/jobs/6803445354)