### PR TITLE
Add functionality to skip TLS verify for mocking HCP in consul

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -31,6 +31,8 @@ const (
 
 	envVarAPITLS = "HCP_API_TLS"
 
+	envVarAuthTLS = "HCP_AUTH_TLS"
+
 	envVarSCADAAddress = "HCP_SCADA_ADDRESS"
 
 	envVarSCADATLS = "HCP_SCADA_TLS"
@@ -118,6 +120,15 @@ func FromEnv() HCPConfigOption {
 				return fmt.Errorf("failed to configure TLS basd on environment variable %s: %w", envVarAPITLS, err)
 			}
 			config.apiTLSConfig = apiTLSConfig
+		}
+
+		// Read Auth TLS setting from environment
+		if authTLSSetting, ok := os.LookupEnv(envVarAuthTLS); ok {
+			authTLSConfig, err := tlsConfigForSetting(authTLSSetting)
+			if err != nil {
+				return fmt.Errorf("failed to configure TLS basd on environment variable %s: %w", envVarAuthTLS, err)
+			}
+			config.authTLSConfig = authTLSConfig
 		}
 
 		// Read SCADA address from environment

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -102,17 +102,20 @@ func TestFromEnv_TLSConfig_Plain(t *testing.T) {
 	// Prepare the environment
 	require.NoError(os.Setenv(envVarAPITLS, tlsSettingDisabled))
 	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingDisabled))
+	require.NoError(os.Setenv(envVarAuthTLS, tlsSettingDisabled))
 
 	// Exercise
 	config := &hcpConfig{
 		apiTLSConfig:   &tls.Config{},
 		scadaTLSConfig: &tls.Config{},
+		authTLSConfig:  &tls.Config{},
 	}
 	require.NoError(apply(config, FromEnv()))
 
 	// Ensure the TLS configuration has been reset
 	require.Nil(config.apiTLSConfig)
 	require.Nil(config.scadaTLSConfig)
+	require.Nil(config.authTLSConfig)
 }
 
 func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
@@ -125,6 +128,7 @@ func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
 	// Prepare the environment
 	require.NoError(os.Setenv(envVarAPITLS, tlsSettingInsecure))
 	require.NoError(os.Setenv(envVarSCADATLS, tlsSettingInsecure))
+	require.NoError(os.Setenv(envVarAuthTLS, tlsSettingInsecure))
 
 	// Exercise
 	config := &hcpConfig{}
@@ -133,6 +137,7 @@ func TestFromEnv_TLSConfig_Insecure(t *testing.T) {
 	// Ensure the TLS configuration is set to insecure
 	require.True(config.apiTLSConfig.InsecureSkipVerify)
 	require.True(config.scadaTLSConfig.InsecureSkipVerify)
+	require.True(config.authTLSConfig.InsecureSkipVerify)
 }
 
 // clearEnv will unset any environment variables that FromEnv might read.


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

When attempting to mock out the HCP api for integration testing for consul the hcp sdk calls out to a specified auth url that has tls enabled. To mock out the HCP bootstrapping and auth token call ( [here](https://github.com/hashicorp/consul/blob/main/agent/hcp/config/config.go#L49) and [here](https://github.com/hashicorp/consul/blob/main/agent/hcp/client.go#L71) )   we are mocking out HCP fully. Without this setting we verify the tls settings on the connection to the "authUrl". This allows us to mock the api without concerning the mock with actually having a valid certificate. 

This follows the precedence of HCP_API_TLS and HCP_SCADA_TLS settings used for testing. None of these settings are used in a production workload. 

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [n/a] <service> SDK added
- [n/a] <service> SDK updated
- [X] Tests added?
- [n/a] Docs updated?