### PR TITLE
add an option to suppress logger logging

### DIFF
--- a/.changelog/192.txt
+++ b/.changelog/192.txt
@@ -1,0 +1,4 @@
+
+```release-note:improvement
+Added option to NewHCPConfig to disable logging from the SDK
+```

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -98,6 +98,9 @@ type hcpConfig struct {
 
 	// noBrowserLogin is an option to prevent automatic browser login when no local credentials are found.
 	noBrowserLogin bool
+
+	// suppressLogging is an option to prevent this SDK from printing anything
+	suppressLogging bool
 }
 
 func (c *hcpConfig) Profile() *profile.UserProfile {

--- a/config/new.go
+++ b/config/new.go
@@ -6,6 +6,8 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -94,6 +96,10 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 		if err := opt(config); err != nil {
 			return nil, fmt.Errorf("failed to apply configuration option: %w", err)
 		}
+	}
+
+	if config.suppressLogging {
+		log.SetOutput(ioutil.Discard)
 	}
 
 	if config.noBrowserLogin {

--- a/config/new.go
+++ b/config/new.go
@@ -99,7 +99,7 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 	}
 
 	if config.suppressLogging {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	if config.noBrowserLogin {

--- a/config/new.go
+++ b/config/new.go
@@ -6,7 +6,7 @@ package config
 import (
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"net/url"

--- a/config/with.go
+++ b/config/with.go
@@ -139,10 +139,19 @@ func WithProfile(p *profile.UserProfile) HCPConfigOption {
 }
 
 // WithoutBrowserLogin disables the automatic opening of the browser login if no valid auth method is found
-// instead force the return of a typed error for users to catch
+// instead force the return of a typed error for users to catch.
 func WithoutBrowserLogin() HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.noBrowserLogin = true
+		return nil
+	}
+}
+
+// WithoutLogging disables this SDK from printing of any kind, this is necessary since there is not a consistent logger
+// that is used throughout the project so a log level option is not sufficient.
+func WithoutLogging() HCPConfigOption {
+	return func(config *hcpConfig) error {
+		config.suppressLogging = true
 		return nil
 	}
 }


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

This pr enables the creation of an SDK client that does not itself print log lines. This is needed because this SDK is used in a CLI for [HCP Vault Secrets](https://github.com/hashicorp/vlt) where we need to control what is printed if anything to the terminal to preserve the UX. In it's currently implementation several raw error messages are printed to STDOUT namely around the web browser authentication flow. One exception to what this PR covers is the logging done via https://github.com/mitchellh/colorstring in [auth/browser.go](https://github.com/hashicorp/hcp-sdk-go/blob/main/auth/browser.go) which is also problematic but would require passing this flag into this interface to disable printing since it does not use the default logger.
