### PR TITLE
auth: use refresh tokens if the session is still valid

### DIFF
--- a/.changelog/196.txt
+++ b/.changelog/196.txt
@@ -1,0 +1,3 @@
+```release-note:improvement
+Use refresh tokens if the session is still valid
+```

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -330,7 +330,7 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty values",
 			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "", "access_token_expiry": "", "session_expiry": "" }`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
 		},
 		{
 			name:          "empty access token",
@@ -345,12 +345,12 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty access token expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "", "session_expiry": "2022-11-20T17:10:59.273429-04:00"}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
 		},
 		{
 			name:          "empty session expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "2022-11-20T17:10:59.273429-04:00", "session_expiry": ""}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
 		},
 	}
 

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -330,7 +330,7 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty values",
 			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "", "access_token_expiry": "", "session_expiry": "" }`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
 		},
 		{
 			name:          "empty access token",
@@ -345,12 +345,12 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty access token expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "", "session_expiry": "2022-11-20T17:10:59.273429-04:00"}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
 		},
 		{
 			name:          "empty session expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "2022-11-20T17:10:59.273429-04:00", "session_expiry": ""}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time \"\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"2006\"",
 		},
 	}
 

--- a/auth/mock.go
+++ b/auth/mock.go
@@ -5,6 +5,7 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"golang.org/x/oauth2"
@@ -15,7 +16,7 @@ type MockSession struct{}
 // GetToken returns some mock token with static data.
 func (s *MockSession) GetToken(ctx context.Context, conf *oauth2.Config) (*oauth2.Token, error) {
 	tok := oauth2.Token{
-		AccessToken:  "SomeAccessToken",
+		AccessToken:  "Some.Access.Token",
 		RefreshToken: "SomeRefreshToken",
 		Expiry:       time.Now().Add(time.Hour * 1),
 	}
@@ -27,9 +28,27 @@ type mockBrowser struct{}
 
 func (b *mockBrowser) GetTokenFromBrowser(ctx context.Context, conf *oauth2.Config) (*oauth2.Token, error) {
 	tok := oauth2.Token{
-		AccessToken:  "SomeNewAccessToken",
-		RefreshToken: "SomeNewRefreshToken",
+		// Cache read expects the access token to look JWT-like
+		AccessToken:  "New.Access.Token",
+		RefreshToken: "NewRefreshToken",
 		Expiry:       time.Now().Add(time.Hour * 1),
 	}
 	return &tok, nil
+}
+
+type mockRefreshTokenSource struct {
+	err bool
+}
+
+func (m *mockRefreshTokenSource) Token() (*oauth2.Token, error) {
+	if m.err {
+		return nil, fmt.Errorf("error")
+	}
+
+	return &oauth2.Token{
+		// Cache read expects the access token to look JWT-like
+		AccessToken:  "Refreshed.Access.Token",
+		RefreshToken: "RefreshedRefreshToken",
+		Expiry:       time.Now().Add(time.Hour * 1),
+	}, nil
 }

--- a/auth/user.go
+++ b/auth/user.go
@@ -22,6 +22,10 @@ var (
 type UserSession struct {
 	browser        Browser
 	NoBrowserLogin bool
+
+	// refreshTokenSource is encapsulated in this closure in order to mock it in
+	// tests
+	refreshTokenSourceFunc func(context.Context, *oauth2.Config, *oauth2.Token) oauth2.TokenSource
 }
 
 // GetToken returns an access token obtained from either an existing session or new browser login.
@@ -33,37 +37,45 @@ func (s *UserSession) GetToken(ctx context.Context, conf *oauth2.Config) (*oauth
 		log.Printf("Failed to read cache from file: %s", readErr.Error())
 	}
 
-	var tok *oauth2.Token
-	var err error
-
 	// Check the expiry of the retrieved token.
-	// If session expiry or the AccessTokenExpiry has passed, then reauthenticate with browser login and reassign token.
-	if readErr != nil || cache.SessionExpiry.Before(time.Now()) || cache.AccessTokenExpiry.Before(time.Now()) {
+	switch {
+	// If the file wasn't found, there is no refresh function, or the session is
+	// fully expired then reauthenticate with browser login and rewrite token.
+	case readErr != nil, cache.SessionExpiry.Before(time.Now()):
 
-		// This is a configuration option set by WithoutBrowserLogin to provide control over when or if the browser is opened
-		// When the flag is true and no valid credentials are found on the system via ClientID:ClientSecret pairing or a previous unexpired browser login, the client returns an error instead of automatically opening a browser
-		if s.NoBrowserLogin {
-			return nil, ErrorNoLocalCredsFound
+		return s.doBrowserLogin(ctx, conf)
+
+	// The access token is expired, but the refresh token should still be
+	// valid. Fetch a new token without having to open the browser and
+	// rewrite the cache file.
+	case cache.AccessTokenExpiry.Before(time.Now()):
+
+		// This allows us to overide with a mock in tests
+		if s.refreshTokenSourceFunc == nil {
+			s.refreshTokenSourceFunc = func(ctx context.Context, conf *oauth2.Config, token *oauth2.Token) oauth2.TokenSource {
+				return conf.TokenSource(ctx, token)
+			}
 		}
 
-		// Login with browser.
-		log.Print("No credentials found, proceeding with browser login.")
-
-		if s.browser == nil {
-			s.browser = &oauthBrowser{}
-		}
-
-		tok, err = s.browser.GetTokenFromBrowser(ctx, conf)
+		// Refresh the token.
+		refreshed, err := s.refreshTokenSourceFunc(ctx, conf, &oauth2.Token{
+			AccessToken:  cache.AccessToken,
+			RefreshToken: cache.RefreshToken,
+			Expiry:       cache.AccessTokenExpiry,
+		}).Token()
 		if err != nil {
-			return nil, fmt.Errorf("failed to get access token: %w", err)
+			// If we fail to refresh, fall back to browser login.
+			log.Printf("Failed to refresh token, falling back to browser login: %s", err.Error())
+			return s.doBrowserLogin(ctx, conf)
 		}
 
-		// Update cache with newly obtained token.
+		// Update cache with newly obtained token. Use the new token details,
+		// but keep the same session expiry.
 		newCache := Cache{
-			AccessToken:       tok.AccessToken,
-			RefreshToken:      tok.RefreshToken,
-			AccessTokenExpiry: tok.Expiry,
-			SessionExpiry:     time.Now().Add(SessionMaxAge),
+			AccessToken:       refreshed.AccessToken,
+			RefreshToken:      refreshed.RefreshToken,
+			AccessTokenExpiry: refreshed.Expiry,
+			SessionExpiry:     cache.SessionExpiry,
 		}
 
 		err = Write(newCache)
@@ -71,12 +83,51 @@ func (s *UserSession) GetToken(ctx context.Context, conf *oauth2.Config) (*oauth
 			log.Printf("Failed to write cache to file: %s", err.Error())
 		}
 
-	} else { // Otherwise return existing, unexpired token to continue existing session.
-		tok = &oauth2.Token{
+		return refreshed, nil
+
+	// Otherwise return existing, unexpired token to continue existing session.
+	default:
+		return &oauth2.Token{
 			AccessToken:  cache.AccessToken,
 			RefreshToken: cache.RefreshToken,
 			Expiry:       cache.AccessTokenExpiry,
-		}
+		}, nil
+	}
+}
+
+func (s *UserSession) doBrowserLogin(ctx context.Context, conf *oauth2.Config) (*oauth2.Token, error) {
+	// This is a configuration option set by WithoutBrowserLogin to provide
+	// control over when or if the browser is opened. When the flag is true and
+	// no valid credentials are found on the system via ClientID:ClientSecret
+	// pairing or a previous unexpired browser login, the client returns an
+	// error instead of automatically opening a browser
+	if s.NoBrowserLogin {
+		return nil, ErrorNoLocalCredsFound
+	}
+
+	// Login with browser.
+	log.Print("No credentials found, proceeding with browser login.")
+
+	if s.browser == nil {
+		s.browser = &oauthBrowser{}
+	}
+
+	tok, err := s.browser.GetTokenFromBrowser(ctx, conf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get access token: %w", err)
+	}
+
+	// Update cache with newly obtained token.
+	newCache := Cache{
+		AccessToken:       tok.AccessToken,
+		RefreshToken:      tok.RefreshToken,
+		AccessTokenExpiry: tok.Expiry,
+		SessionExpiry:     time.Now().Add(SessionMaxAge),
+	}
+
+	err = Write(newCache)
+	if err != nil {
+		log.Printf("Failed to write cache to file: %s", err.Error())
 	}
 
 	return tok, nil

--- a/auth/user.go
+++ b/auth/user.go
@@ -39,8 +39,8 @@ func (s *UserSession) GetToken(ctx context.Context, conf *oauth2.Config) (*oauth
 
 	// Check the expiry of the retrieved token.
 	switch {
-	// If the file wasn't found, there is no refresh function, or the session is
-	// fully expired then reauthenticate with browser login and rewrite token.
+	// If the file wasn't found or the session is fully expired then
+	// reauthenticate with browser login and rewrite token.
 	case readErr != nil, cache.SessionExpiry.Before(time.Now()):
 
 		return s.doBrowserLogin(ctx, conf)

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -89,7 +89,7 @@ type hcpConfig struct {
 	// set to nil if TLS should be disabled.
 	scadaTLSConfig *tls.Config
 
-	// session is responsible for getting an access token fron our identity provider.
+	// session is responsible for getting an access token from our identity provider.
 	// A mock can be used in tests.
 	session auth.Session
 

--- a/config/new_test.go
+++ b/config/new_test.go
@@ -64,7 +64,7 @@ func TestNew_MockSession(t *testing.T) {
 	// Ensure the values have been set accordingly
 	tok, err := config.Token()
 	require.NoError(err)
-	require.Equal("SomeAccessToken", tok.AccessToken)
+	require.Equal("Some.Access.Token", tok.AccessToken)
 	require.Equal("SomeRefreshToken", tok.RefreshToken)
 }
 


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

This changes the sdk's authentication logic to use a refresh token if the session expiry has not passed. Previously it would always do a browser login if the access token was expired (1 hr). Now CLIs can be logged in for up to 24 hours.

On refresh, we will re-write the cache file so the refreshed access token will be used until it expires. If we fail to refresh then it will fall back to doing a browser login.

I also fixed a few tests that were not executing as expected.

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [X] Tests added
- [ ] Docs updated?