### PR TITLE
Workload Identity Federation Auth

### DIFF
--- a/.changelog/199.txt
+++ b/.changelog/199.txt
@@ -1,0 +1,3 @@
+```release-note:feature
+SDK can authenticate using Workload Identity Federation.
+```

--- a/auth/cache_test.go
+++ b/auth/cache_test.go
@@ -330,7 +330,7 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty values",
 			rawJSON:       []byte(`{ "access_token": "", "refresh_token": "", "access_token_expiry": "", "session_expiry": "" }`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time",
 		},
 		{
 			name:          "empty access token",
@@ -345,12 +345,12 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 		{
 			name:          "empty access token expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "", "session_expiry": "2022-11-20T17:10:59.273429-04:00"}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time",
 		},
 		{
 			name:          "empty session expiry",
 			rawJSON:       []byte(`{ "access_token": "myaccesstoken", "refresh_token": "myrefreshtoken", "access_token_expiry": "2022-11-20T17:10:59.273429-04:00", "session_expiry": ""}`),
-			expectedError: "failed to unmarshal the raw data to json: parsing time \"\\\"\\\"\" as \"\\\"2006-01-02T15:04:05Z07:00\\\"\": cannot parse \"\\\"\" as \"2006\"",
+			expectedError: "failed to unmarshal the raw data to json: parsing time",
 		},
 	}
 
@@ -360,7 +360,7 @@ func TestJsonToCache_InvalidFormat(t *testing.T) {
 
 			_, err := jsonToCache(testCase.rawJSON)
 			require.Error(err)
-			require.EqualError(err, testCase.expectedError)
+			require.ErrorContains(err, testCase.expectedError)
 		})
 	}
 }

--- a/auth/workload/aws.go
+++ b/auth/workload/aws.go
@@ -1,0 +1,544 @@
+package workload
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+const (
+	// Environment Variable Reference:
+	// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+
+	// awsEnvRegion is the region to send requests to. It takes precendence of
+	// default region.
+	awsEnvRegion = "AWS_REGION"
+
+	// awsEnvDefaultRegion is where requests will be sent to by default, if not
+	// overriden.
+	awsEnvDefaultRegion = "AWS_DEFAULT_REGION"
+
+	// awsEnvAccessKeyId stores the AWS access key.
+	awsEnvAccessKeyId = "AWS_ACCESS_KEY_ID"
+
+	// awsEnvSecretAccessKeyId stores the secret key associated with the access key.
+	awsEnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
+
+	// awsEnvSessionToken stores session token value that is required if you are
+	// using temporary security credentials that you retrieved directly from AWS
+	// STS operations.
+	awsEnvSessionToken = "AWS_SESSION_TOKEN"
+
+	// awsRegionURL is the metadata URL to discover the instances current
+	// region.
+	awsRegionURL = "http://169.254.169.254/latest/meta-data/placement/region"
+
+	// awsSecurityCredentialsURL is used to find the assigned role and retrieve
+	// its credentials.
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
+	awsSecurityCredentialsURL = "http://169.254.169.254/latest/meta-data/iam/security-credentials"
+
+	// awsSessionTokenURL retrieves a short lived session token.
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html
+	awsSessionTokenURL = "http://169.254.169.254/latest/api/token"
+
+	// awsIMDSv2SessionTtlHeader is used to configure the session token TTL.
+	awsIMDSv2SessionTtlHeader = "X-aws-ec2-metadata-token-ttl-seconds"
+
+	// awsIMDSv2SessionTtl is the session ttl we request.
+	awsIMDSv2SessionTtl = "300"
+
+	// awsIMDSv2SessionTokenHeader is used to pass the short lived session
+	// token to an IMDSv2 endpoint.
+	awsIMDSv2SessionTokenHeader = "X-aws-ec2-metadata-token"
+
+	// awsRegionalSTSEndpoint is the regional STS endpoint. The region must be
+	// formatted in.
+	awsRegionalSTSEndpoint = "https://sts.%s.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15"
+
+	// awsSecurityTokenHeader is the header to pass the short lived security
+	// token.
+	awsSecurityTokenHeader = "x-amz-security-token"
+
+	// awsDateHeader is the header to pass the timestamp of the request.
+	awsDateHeader = "x-amz-date"
+
+	// awsDateFormat is the how to format the date timestamp
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/signing-elements.html#date
+	awsDateFormat = "20060102T150405Z"
+
+	// awsDateShortFormat is the how to format the date in the credential
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/signing-elements.html#authentication
+	awsDateShortFormat = "20060102"
+
+	// awsAlgorithm indicates how the request was signed
+	awsAlgorithm = "AWS4-HMAC-SHA256"
+
+	// awsRequestType is used to terminate the signed credential.
+	// https://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+	awsRequestType = "aws4_request"
+
+	// hcpWorkloadIdentityProviderHeader is the header used to reference the
+	// workload identity provider the token exchange is meant for. The header
+	// must be included in the signed request.
+	hcpWorkloadIdentityProviderHeader = "x-hcp-workload-identity-provider"
+)
+
+// AWSCredentialSource sources credentials by interacting with the AWS IMDS
+// endpoint to sign an AWS GetCallerIdentity request. The signed request can
+// then be used by HCP to return HCP Service Principal credentials based on the
+// identity of the AWS workload.
+type AWSCredentialSource struct {
+	// IMDSv2 indicates that IMDSv2 endpoint should be used.
+	IMDSv2 bool `json:"imds_v2"`
+
+	// client is the http client used to make requests
+	client *http.Client
+
+	// now is a function that returns the current time
+	now func() time.Time
+}
+
+// getCallerIdentityReq returns the signed AWS GetCallerIdentity request.
+func (ac *AWSCredentialSource) getCallerIdentityReq(wipResourceName string) (*callerIdentityRequest, error) {
+	if ac.client == nil {
+		ac.client = cleanhttp.DefaultPooledClient()
+	}
+
+	if ac.now == nil {
+		ac.now = time.Now
+	}
+
+	// get the request signer
+	s, err := newAWSRequestSigner(ac.IMDSv2, ac.client, ac.now)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the request to the regional AWS STS GetCallerIdentity API.
+	req, err := http.NewRequest("POST", fmt.Sprintf(awsRegionalSTSEndpoint, s.region), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the workload identity provider resource name as a signed header. This
+	// ensures that the token exchange is for only the specified resource.
+	req.Header.Add(hcpWorkloadIdentityProviderHeader, wipResourceName)
+
+	// Sign the request
+	if err := s.SignRequest(req); err != nil {
+		return nil, fmt.Errorf("failed to sign GetCallerIdentity request: %v", err)
+	}
+
+	// Convert the request
+	idReq := &callerIdentityRequest{
+		Headers: map[string]string{},
+		Method:  req.Method,
+		URL:     req.URL.String(),
+	}
+	for k, values := range req.Header {
+		value := ""
+		if len(values) > 0 {
+			value = values[0]
+		}
+		idReq.Headers[k] = value
+	}
+
+	return idReq, nil
+}
+
+// callerIdentityRequest is the signed request for the GetCallerIdentity
+// endpoint.
+type callerIdentityRequest struct {
+	// headers is the HTTP request headers. This must include:
+	//
+	// x-amz-date: the date of the request
+	//  host: the host of the request, e.g. sts.amazonaws.com
+	//  x-hcp-workload-identity-provider: the resource_name of the workload
+	//    identity provider the token exchange will be conducted against.
+	//  Authorization: The AWS Signature for the request.
+	//  X-Amz-Security-Token: The temporary security credentials' session used
+	//    to sign the request. Described here:
+	//    https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#temporary-security-credentials
+	Headers map[string]string `json:"headers,omitempty"`
+
+	// method is the method of the HTTP request.
+	Method string `json:"method,omitempty"`
+
+	// url is the URL of the AWS endpoint being called.
+	URL string `json:"url,omitempty"`
+}
+
+type awsRequestSigner struct {
+	// client is the http client used to make requests
+	client *http.Client
+
+	// imdsSessionToken is the session token to send to IMDSv2 requests
+	imdsSessionToken string
+
+	// region is the AWS region being operated in
+	region string
+
+	// AWS credentials
+	creds awsSecurityCredentials
+
+	// now is a function that returns the current time
+	now func() time.Time
+}
+
+type awsSecurityCredentials struct {
+	AccessKeyID     string `json:"AccessKeyID"`
+	SecretAccessKey string `json:"SecretAccessKey"`
+	SecurityToken   string `json:"Token"`
+}
+
+func newAWSRequestSigner(imdsV2 bool, client *http.Client, now func() time.Time) (*awsRequestSigner, error) {
+	s := &awsRequestSigner{
+		client: client,
+		now:    now,
+	}
+	s.sourceEnvVars()
+
+	// Create a request context with a deadline
+	reqCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	// If we are configured to use IMDSv2 and we haven't sourced everything we
+	// need from environment variables then get a session token.
+	if imdsV2 && (s.region == "" || s.creds.AccessKeyID == "") {
+		if err := s.getSessionToken(reqCtx); err != nil {
+			return nil, err
+		}
+	}
+
+	if err := s.getRegion(reqCtx); err != nil {
+		return nil, err
+	}
+
+	if err := s.getCredentials(reqCtx); err != nil {
+		return nil, err
+	}
+
+	return s, nil
+}
+
+// SignRequest adds the appropriate headers to an http.Request
+// or returns an error if something prevented this.
+func (s *awsRequestSigner) SignRequest(req *http.Request) error {
+	req.Header.Add("host", req.Host)
+
+	if s.creds.SecurityToken != "" {
+		req.Header.Add(awsSecurityTokenHeader, s.creds.SecurityToken)
+	}
+
+	now := s.now()
+	if req.Header.Get("date") == "" {
+		req.Header.Add(awsDateHeader, now.Format(awsDateFormat))
+	}
+
+	authorizationCode, err := s.generateAuthentication(req, now)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Authorization", authorizationCode)
+	return nil
+}
+
+func (s *awsRequestSigner) sourceEnvVars() {
+	// Try to determine the region
+	region, regionOk := os.LookupEnv(awsEnvRegion)
+	if regionOk {
+		s.region = region
+	}
+
+	defaultRegion, defaultOk := os.LookupEnv(awsEnvDefaultRegion)
+	if !regionOk && defaultOk {
+		s.region = defaultRegion
+	}
+
+	// Try to get the AWS credentials
+	accessKey, accessKeyOk := os.LookupEnv(awsEnvAccessKeyId)
+	secretKey, secretKeyOk := os.LookupEnv(awsEnvSecretAccessKey)
+	sessionToken := os.Getenv(awsEnvSessionToken)
+	if accessKeyOk && secretKeyOk {
+		s.creds.AccessKeyID = accessKey
+		s.creds.SecretAccessKey = secretKey
+		s.creds.SecurityToken = sessionToken
+	}
+}
+
+func (s *awsRequestSigner) getSessionToken(ctx context.Context) error {
+	// Create the request to retrieve the session token.
+	req, err := http.NewRequestWithContext(ctx, "PUT", awsSessionTokenURL, nil)
+	if err != nil {
+		return err
+	}
+
+	// Configure the requested token TTL
+	req.Header.Add(awsIMDSv2SessionTtlHeader, awsIMDSv2SessionTtl)
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed retrieving AWS session token from metadata endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("failed reading AWS session token response from metadata endpoint: %v", err)
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("AWS session token endpoint returned status code %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Store the token in the header.
+	s.imdsSessionToken = string(respBody)
+
+	return nil
+}
+
+func (s *awsRequestSigner) getRegion(ctx context.Context) error {
+	// Check if we retrieved this from the environment already
+	if s.region != "" {
+		return nil
+	}
+
+	// Create the request to retrieve the region
+	req, err := http.NewRequestWithContext(ctx, "GET", awsRegionURL, nil)
+	if err != nil {
+		return err
+	}
+
+	if s.imdsSessionToken != "" {
+		req.Header.Add(awsIMDSv2SessionTokenHeader, s.imdsSessionToken)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed retrieving AWS region from metadata endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("failed reading AWS region response from metadata endpoint: %v", err)
+
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("metadata region endpoint returned status %d: %v", resp.StatusCode, string(respBody))
+	}
+
+	// The only value returned is the region
+	s.region = string(respBody)
+	return nil
+}
+
+func (s *awsRequestSigner) getCredentials(ctx context.Context) error {
+	// Check if we retrieved these from the environment already
+	if s.creds.AccessKeyID != "" {
+		return nil
+	}
+
+	role, err := s.getRoleName(ctx)
+	if err != nil {
+		return err
+	}
+
+	// Create the request to retrieve the role
+	req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/%s", awsSecurityCredentialsURL, role), nil)
+	if err != nil {
+		return err
+	}
+
+	if s.imdsSessionToken != "" {
+		req.Header.Add(awsIMDSv2SessionTokenHeader, s.imdsSessionToken)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed retrieving security credentials from metadata endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return fmt.Errorf("failed reading AWS security credential response from metadata endpoint: %v", err)
+
+	}
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("metadata security credential endpoint returned status %d: %v", resp.StatusCode, string(respBody))
+	}
+
+	if err := json.Unmarshal(respBody, &s.creds); err != nil {
+		return fmt.Errorf("failed to unmarshall security credential response: %v", err)
+	}
+
+	return nil
+}
+
+func (s *awsRequestSigner) getRoleName(ctx context.Context) (string, error) {
+	// Create the request to retrieve the role
+	req, err := http.NewRequestWithContext(ctx, "GET", awsSecurityCredentialsURL, nil)
+	if err != nil {
+		return "", err
+	}
+
+	if s.imdsSessionToken != "" {
+		req.Header.Add(awsIMDSv2SessionTokenHeader, s.imdsSessionToken)
+	}
+
+	resp, err := s.client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed retrieving role name from metadata endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("failed reading AWS security credential response from metadata endpoint: %v", err)
+
+	}
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("metadata security credential endpoint returned status %d: %v", resp.StatusCode, string(respBody))
+	}
+
+	return string(respBody), nil
+}
+
+// generateAuthentication generates the authentication header for the given
+// request.
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html
+func (s *awsRequestSigner) generateAuthentication(req *http.Request, timestamp time.Time) (string, error) {
+	canonicalHeaderColumns, canonicalHeaderData := canonicalHeaders(req)
+
+	dateStamp := timestamp.Format(awsDateShortFormat)
+	credentialScope := fmt.Sprintf("%s/%s/%s/%s", dateStamp, s.region, "sts", awsRequestType)
+
+	requestString, err := canonicalRequest(req, canonicalHeaderColumns, canonicalHeaderData)
+	if err != nil {
+		return "", err
+	}
+	requestHash, err := getSha256([]byte(requestString))
+	if err != nil {
+		return "", err
+	}
+
+	signingKey := []byte("AWS4" + s.creds.SecretAccessKey)
+	stringToSign := fmt.Sprintf("%s\n%s\n%s\n%s", awsAlgorithm, timestamp.Format(awsDateFormat), credentialScope, requestHash)
+	for _, signingInput := range []string{
+		dateStamp, s.region, "sts", awsRequestType, stringToSign,
+	} {
+		signingKey, err = getHmacSha256(signingKey, []byte(signingInput))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("%s Credential=%s/%s, SignedHeaders=%s, Signature=%s", awsAlgorithm, s.creds.AccessKeyID, credentialScope, canonicalHeaderColumns, hex.EncodeToString(signingKey)), nil
+}
+
+func getSha256(input []byte) (string, error) {
+	hash := sha256.New()
+	if _, err := hash.Write(input); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(hash.Sum(nil)), nil
+}
+
+func getHmacSha256(key, input []byte) ([]byte, error) {
+	hash := hmac.New(sha256.New, key)
+	if _, err := hash.Write(input); err != nil {
+		return nil, err
+	}
+	return hash.Sum(nil), nil
+}
+
+func canonicalHeaders(req *http.Request) (string, string) {
+	// Header keys need to be sorted alphabetically.
+	var headers []string
+	lowerCaseHeaders := make(http.Header)
+	for k, v := range req.Header {
+		k := strings.ToLower(k)
+		if _, ok := lowerCaseHeaders[k]; ok {
+			// include additional values
+			lowerCaseHeaders[k] = append(lowerCaseHeaders[k], v...)
+		} else {
+			headers = append(headers, k)
+			lowerCaseHeaders[k] = v
+		}
+	}
+	sort.Strings(headers)
+
+	var fullHeaders bytes.Buffer
+	for _, header := range headers {
+		headerValue := strings.Join(lowerCaseHeaders[header], ",")
+		fullHeaders.WriteString(header)
+		fullHeaders.WriteRune(':')
+		fullHeaders.WriteString(headerValue)
+		fullHeaders.WriteRune('\n')
+	}
+
+	return strings.Join(headers, ";"), fullHeaders.String()
+}
+
+func requestDataHash(req *http.Request) (string, error) {
+	var requestData []byte
+	if req.Body != nil {
+		requestBody, err := req.GetBody()
+		if err != nil {
+			return "", err
+		}
+		defer requestBody.Close()
+
+		requestData, err = ioutil.ReadAll(io.LimitReader(requestBody, 1<<20))
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return getSha256(requestData)
+}
+
+func canonicalRequest(req *http.Request, canonicalHeaderColumns, canonicalHeaderData string) (string, error) {
+	dataHash, err := requestDataHash(req)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s\n%s\n%s\n%s\n%s\n%s", req.Method, canonicalPath(req), canonicalQuery(req), canonicalHeaderData, canonicalHeaderColumns, dataHash), nil
+}
+
+func canonicalPath(req *http.Request) string {
+	result := req.URL.EscapedPath()
+	if result == "" {
+		return "/"
+	}
+	return path.Clean(result)
+}
+
+func canonicalQuery(req *http.Request) string {
+	queryValues := req.URL.Query()
+	for queryKey := range queryValues {
+		sort.Strings(queryValues[queryKey])
+	}
+	return queryValues.Encode()
+}

--- a/auth/workload/aws.go
+++ b/auth/workload/aws.go
@@ -24,16 +24,16 @@ const (
 	// Environment Variable Reference:
 	// https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
 
-	// awsEnvRegion is the region to send requests to. It takes precendence of
+	// awsEnvRegion is the region to send requests to. It takes precedence of
 	// default region.
 	awsEnvRegion = "AWS_REGION"
 
 	// awsEnvDefaultRegion is where requests will be sent to by default, if not
-	// overriden.
+	// overridden.
 	awsEnvDefaultRegion = "AWS_DEFAULT_REGION"
 
-	// awsEnvAccessKeyId stores the AWS access key.
-	awsEnvAccessKeyId = "AWS_ACCESS_KEY_ID"
+	// awsEnvAccessKeyID stores the AWS access key.
+	awsEnvAccessKeyID = "AWS_ACCESS_KEY_ID"
 
 	// awsEnvSecretAccessKeyId stores the secret key associated with the access key.
 	awsEnvSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
@@ -56,11 +56,11 @@ const (
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-metadata-v2-how-it-works.html
 	awsSessionTokenURL = "http://169.254.169.254/latest/api/token"
 
-	// awsIMDSv2SessionTtlHeader is used to configure the session token TTL.
-	awsIMDSv2SessionTtlHeader = "X-aws-ec2-metadata-token-ttl-seconds"
+	// awsIMDSv2SessionTTLHeader is used to configure the session token TTL.
+	awsIMDSv2SessionTTLHeader = "X-aws-ec2-metadata-token-ttl-seconds"
 
-	// awsIMDSv2SessionTtl is the session ttl we request.
-	awsIMDSv2SessionTtl = "300"
+	// awsIMDSv2SessionTTL is the session ttl we request.
+	awsIMDSv2SessionTTL = "300"
 
 	// awsIMDSv2SessionTokenHeader is used to pass the short lived session
 	// token to an IMDSv2 endpoint.
@@ -272,7 +272,7 @@ func (s *awsRequestSigner) sourceEnvVars() {
 	}
 
 	// Try to get the AWS credentials
-	accessKey, accessKeyOk := os.LookupEnv(awsEnvAccessKeyId)
+	accessKey, accessKeyOk := os.LookupEnv(awsEnvAccessKeyID)
 	secretKey, secretKeyOk := os.LookupEnv(awsEnvSecretAccessKey)
 	sessionToken := os.Getenv(awsEnvSessionToken)
 	if accessKeyOk && secretKeyOk {
@@ -290,7 +290,7 @@ func (s *awsRequestSigner) getSessionToken(ctx context.Context) error {
 	}
 
 	// Configure the requested token TTL
-	req.Header.Add(awsIMDSv2SessionTtlHeader, awsIMDSv2SessionTtl)
+	req.Header.Add(awsIMDSv2SessionTTLHeader, awsIMDSv2SessionTTL)
 
 	resp, err := s.client.Do(req)
 	if err != nil {

--- a/auth/workload/aws_test.go
+++ b/auth/workload/aws_test.go
@@ -1,0 +1,325 @@
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	wipResourceName = "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws"
+	accessKeyID     = "ASIASDOME5YRY6JUQQ7O"
+	secretAccessKey = "9mpg9prjH54qmpVB99l1YS8mMraFs8WvrZJC+C2o"
+	securityToken   = "IQoJb3JpZ2luX2VjEOX//////////wEaCXVzLWVhc3QtMSJIMEYCIQDVVsx2ozIeu2VgW9AYbwjrR3hhOYuncJCPWHYjeKh6XwIhAKPK3WK77+Q+z//E2d1R332IVAJN3svmSO+oBi1M2t3tKrsFCH4QARoMMTQ0ODQ2NDE3NDQzIgzrrhKJVjIO3x6lvPIqmAWSplqdzMuuhOrTIhGASwxI2tMCZlTIDKTV9upDfUfecMfV2swtd9EATvhWMztoKzNfG+r175/x7U8C9Bsb5WMr9MAx0v821HSRcbWv3WPP5F3mq/A9sI4I5j4jJx8NFwxyF96k7qhfffnVjG37oyuNNAcL18IsuexHEFiVAnqaj4plaBP3ea6en2ANksHcNn3UgIsat8bphpHJxwZ5O3Jh3sIwWu/KNXSrPyWzGC4/N/SpkThKNckL6MDSJZj2fW9WRO56TSynz2mh2CQGF5rIOjpflk2YKll65xAHTj863ELglo89950rB4K00lRSB0k8xAeS4uoJcPk9HJ2PPcY0LH6gkONR+QH2y28TRDfDPVZcJWzGyw/PZl0qWcgXEo43CzkmLD36Fa4F8P05ipeSPW0z3G+xUNyUqupm8VN4QD8XsUpmTICobBQhFLs3MCRFwSQexjnzkjDDTJz/HNTfJGKsOD09o7gRdlLVKxrQw/JM/A2dsaDuMW6KqjmrOsE804eUUnucBnNRObfeMBUz+QneSynMSIysIAnZ3STUBRfHjuj/YgIg3uaN4h84PvFfrB9WOKwuG0QCkJFoIBtborg0y1vWnqf/Kp8EAy3lwr+IE6/t/5dHPtCp6uUxmT8O/yW4PHA2/RufQ8isazIt/a/IdVHMht8VaYJRv5d9OyiNL5Ohh9WkesJ3SPgv2tEpJU4z9b1IiN18i0Tk30H1+nuQKyQsTjX2nB6RnKIpNmNseQKIuMFvOt3MqvquseWtMKjiApUauFBRe4Xh3tzA0w0jSSOPfY6tOO7p6D2j1vsF8X2Bt+l6/NUNgyGE6mgWm0vAWkK0nk2n7t/1DSLTB0NemS5iQcYhl8x9sadIUGTtah/9pLEKMLDJkKYGOrABoU0ILA/R+ATv9zfk3sL8+FdhzckPg6XHRHlZPHT7CC+sdppijioSmnecS9mF/7kf/Qrv73UXGY6drdmV7TEXW3GqoINiN6VnLhVwXlBmKtKMm0njDnfPX1MHrY++ZObt+nqAlhZQy6LP6CL1U38Pk5yXA1+j14J4ZY1E+25heKQY95Zn3yHGnXxYy8A1ZKo+9jbihWhDuuZIrizN5QNid+QYtxEFJ7eod2U84bll21o="
+)
+
+func testNow() time.Time {
+	return time.Date(2023, 7, 28, 15, 25, 4, 3, time.UTC)
+}
+
+func TestAWSCredentialSource_getCallerID(t *testing.T) {
+	type env struct {
+		region          bool
+		accessKeyID     bool
+		secretAccessKey bool
+		securityToken   bool
+	}
+
+	tests := []struct {
+		name string
+
+		// whether we are using v2
+		v2 bool
+
+		// env controls whether the values are passed via env vars. If not they
+		// are returned from the test imds server
+		env env
+
+		// values to be returned
+		region             string
+		rolename           string
+		accessKeyID        string
+		secretAccessKey    string
+		securityToken      string
+		imdsv2SessionToken string
+		wip                string
+
+		// expected response
+		want *callerIdentityRequest
+	}{
+		{
+			name: "with token env",
+			env: env{
+				region:          true,
+				accessKeyID:     true,
+				secretAccessKey: true,
+				securityToken:   true,
+			},
+			v2:              true,
+			region:          "us-east-1",
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+			securityToken:   securityToken,
+			wip:             wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-hcp-workload-identity-provider, Signature=4678f0beee2b89029de438cc2b75625b7074a5031304bb840c19f494f33bff6f",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Amz-Security-Token":             "IQoJb3JpZ2luX2VjEOX//////////wEaCXVzLWVhc3QtMSJIMEYCIQDVVsx2ozIeu2VgW9AYbwjrR3hhOYuncJCPWHYjeKh6XwIhAKPK3WK77+Q+z//E2d1R332IVAJN3svmSO+oBi1M2t3tKrsFCH4QARoMMTQ0ODQ2NDE3NDQzIgzrrhKJVjIO3x6lvPIqmAWSplqdzMuuhOrTIhGASwxI2tMCZlTIDKTV9upDfUfecMfV2swtd9EATvhWMztoKzNfG+r175/x7U8C9Bsb5WMr9MAx0v821HSRcbWv3WPP5F3mq/A9sI4I5j4jJx8NFwxyF96k7qhfffnVjG37oyuNNAcL18IsuexHEFiVAnqaj4plaBP3ea6en2ANksHcNn3UgIsat8bphpHJxwZ5O3Jh3sIwWu/KNXSrPyWzGC4/N/SpkThKNckL6MDSJZj2fW9WRO56TSynz2mh2CQGF5rIOjpflk2YKll65xAHTj863ELglo89950rB4K00lRSB0k8xAeS4uoJcPk9HJ2PPcY0LH6gkONR+QH2y28TRDfDPVZcJWzGyw/PZl0qWcgXEo43CzkmLD36Fa4F8P05ipeSPW0z3G+xUNyUqupm8VN4QD8XsUpmTICobBQhFLs3MCRFwSQexjnzkjDDTJz/HNTfJGKsOD09o7gRdlLVKxrQw/JM/A2dsaDuMW6KqjmrOsE804eUUnucBnNRObfeMBUz+QneSynMSIysIAnZ3STUBRfHjuj/YgIg3uaN4h84PvFfrB9WOKwuG0QCkJFoIBtborg0y1vWnqf/Kp8EAy3lwr+IE6/t/5dHPtCp6uUxmT8O/yW4PHA2/RufQ8isazIt/a/IdVHMht8VaYJRv5d9OyiNL5Ohh9WkesJ3SPgv2tEpJU4z9b1IiN18i0Tk30H1+nuQKyQsTjX2nB6RnKIpNmNseQKIuMFvOt3MqvquseWtMKjiApUauFBRe4Xh3tzA0w0jSSOPfY6tOO7p6D2j1vsF8X2Bt+l6/NUNgyGE6mgWm0vAWkK0nk2n7t/1DSLTB0NemS5iQcYhl8x9sadIUGTtah/9pLEKMLDJkKYGOrABoU0ILA/R+ATv9zfk3sL8+FdhzckPg6XHRHlZPHT7CC+sdppijioSmnecS9mF/7kf/Qrv73UXGY6drdmV7TEXW3GqoINiN6VnLhVwXlBmKtKMm0njDnfPX1MHrY++ZObt+nqAlhZQy6LP6CL1U38Pk5yXA1+j14J4ZY1E+25heKQY95Zn3yHGnXxYy8A1ZKo+9jbihWhDuuZIrizN5QNid+QYtxEFJ7eod2U84bll21o=",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name: "without token env",
+			env: env{
+				region:          true,
+				accessKeyID:     true,
+				secretAccessKey: true,
+				securityToken:   false,
+			},
+			region:          "us-east-1",
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+			wip:             wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-hcp-workload-identity-provider, Signature=30deb4075f257d5a8e77a8b8b4d2fa962386e4c88fad954c56367df201f2943d",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name:            "without token all metadata",
+			region:          "us-east-1",
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+			wip:             wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-hcp-workload-identity-provider, Signature=30deb4075f257d5a8e77a8b8b4d2fa962386e4c88fad954c56367df201f2943d",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name:            "with token all metadata v1",
+			region:          "us-east-1",
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+			securityToken:   securityToken,
+			wip:             wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-hcp-workload-identity-provider, Signature=30deb4075f257d5a8e77a8b8b4d2fa962386e4c88fad954c56367df201f2943d",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name:               "with token all metadata v2",
+			v2:                 true,
+			imdsv2SessionToken: "test-session-token",
+			region:             "us-east-1",
+			accessKeyID:        accessKeyID,
+			secretAccessKey:    secretAccessKey,
+			securityToken:      securityToken,
+			wip:                wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-hcp-workload-identity-provider, Signature=4678f0beee2b89029de438cc2b75625b7074a5031304bb840c19f494f33bff6f",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Amz-Security-Token":             "IQoJb3JpZ2luX2VjEOX//////////wEaCXVzLWVhc3QtMSJIMEYCIQDVVsx2ozIeu2VgW9AYbwjrR3hhOYuncJCPWHYjeKh6XwIhAKPK3WK77+Q+z//E2d1R332IVAJN3svmSO+oBi1M2t3tKrsFCH4QARoMMTQ0ODQ2NDE3NDQzIgzrrhKJVjIO3x6lvPIqmAWSplqdzMuuhOrTIhGASwxI2tMCZlTIDKTV9upDfUfecMfV2swtd9EATvhWMztoKzNfG+r175/x7U8C9Bsb5WMr9MAx0v821HSRcbWv3WPP5F3mq/A9sI4I5j4jJx8NFwxyF96k7qhfffnVjG37oyuNNAcL18IsuexHEFiVAnqaj4plaBP3ea6en2ANksHcNn3UgIsat8bphpHJxwZ5O3Jh3sIwWu/KNXSrPyWzGC4/N/SpkThKNckL6MDSJZj2fW9WRO56TSynz2mh2CQGF5rIOjpflk2YKll65xAHTj863ELglo89950rB4K00lRSB0k8xAeS4uoJcPk9HJ2PPcY0LH6gkONR+QH2y28TRDfDPVZcJWzGyw/PZl0qWcgXEo43CzkmLD36Fa4F8P05ipeSPW0z3G+xUNyUqupm8VN4QD8XsUpmTICobBQhFLs3MCRFwSQexjnzkjDDTJz/HNTfJGKsOD09o7gRdlLVKxrQw/JM/A2dsaDuMW6KqjmrOsE804eUUnucBnNRObfeMBUz+QneSynMSIysIAnZ3STUBRfHjuj/YgIg3uaN4h84PvFfrB9WOKwuG0QCkJFoIBtborg0y1vWnqf/Kp8EAy3lwr+IE6/t/5dHPtCp6uUxmT8O/yW4PHA2/RufQ8isazIt/a/IdVHMht8VaYJRv5d9OyiNL5Ohh9WkesJ3SPgv2tEpJU4z9b1IiN18i0Tk30H1+nuQKyQsTjX2nB6RnKIpNmNseQKIuMFvOt3MqvquseWtMKjiApUauFBRe4Xh3tzA0w0jSSOPfY6tOO7p6D2j1vsF8X2Bt+l6/NUNgyGE6mgWm0vAWkK0nk2n7t/1DSLTB0NemS5iQcYhl8x9sadIUGTtah/9pLEKMLDJkKYGOrABoU0ILA/R+ATv9zfk3sL8+FdhzckPg6XHRHlZPHT7CC+sdppijioSmnecS9mF/7kf/Qrv73UXGY6drdmV7TEXW3GqoINiN6VnLhVwXlBmKtKMm0njDnfPX1MHrY++ZObt+nqAlhZQy6LP6CL1U38Pk5yXA1+j14J4ZY1E+25heKQY95Zn3yHGnXxYy8A1ZKo+9jbihWhDuuZIrizN5QNid+QYtxEFJ7eod2U84bll21o=",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name: "region env var v1",
+			env: env{
+				region: true,
+			},
+			rolename:        "test-role",
+			region:          "us-east-1",
+			accessKeyID:     accessKeyID,
+			secretAccessKey: secretAccessKey,
+			wip:             wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-hcp-workload-identity-provider, Signature=30deb4075f257d5a8e77a8b8b4d2fa962386e4c88fad954c56367df201f2943d",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+		{
+			name: "region env var v2",
+			env: env{
+				region: true,
+			},
+			v2:                 true,
+			imdsv2SessionToken: "test-session-token",
+			rolename:           "test-role",
+			region:             "us-east-1",
+			accessKeyID:        accessKeyID,
+			secretAccessKey:    secretAccessKey,
+			securityToken:      securityToken,
+			wip:                wipResourceName,
+			want: &callerIdentityRequest{
+				Headers: map[string]string{
+					"Authorization":                    "AWS4-HMAC-SHA256 Credential=ASIASDOME5YRY6JUQQ7O/20230728/us-east-1/sts/aws4_request, SignedHeaders=host;x-amz-date;x-amz-security-token;x-hcp-workload-identity-provider, Signature=4678f0beee2b89029de438cc2b75625b7074a5031304bb840c19f494f33bff6f",
+					"Host":                             "sts.us-east-1.amazonaws.com",
+					"X-Amz-Date":                       "20230728T152504Z",
+					"X-Amz-Security-Token":             "IQoJb3JpZ2luX2VjEOX//////////wEaCXVzLWVhc3QtMSJIMEYCIQDVVsx2ozIeu2VgW9AYbwjrR3hhOYuncJCPWHYjeKh6XwIhAKPK3WK77+Q+z//E2d1R332IVAJN3svmSO+oBi1M2t3tKrsFCH4QARoMMTQ0ODQ2NDE3NDQzIgzrrhKJVjIO3x6lvPIqmAWSplqdzMuuhOrTIhGASwxI2tMCZlTIDKTV9upDfUfecMfV2swtd9EATvhWMztoKzNfG+r175/x7U8C9Bsb5WMr9MAx0v821HSRcbWv3WPP5F3mq/A9sI4I5j4jJx8NFwxyF96k7qhfffnVjG37oyuNNAcL18IsuexHEFiVAnqaj4plaBP3ea6en2ANksHcNn3UgIsat8bphpHJxwZ5O3Jh3sIwWu/KNXSrPyWzGC4/N/SpkThKNckL6MDSJZj2fW9WRO56TSynz2mh2CQGF5rIOjpflk2YKll65xAHTj863ELglo89950rB4K00lRSB0k8xAeS4uoJcPk9HJ2PPcY0LH6gkONR+QH2y28TRDfDPVZcJWzGyw/PZl0qWcgXEo43CzkmLD36Fa4F8P05ipeSPW0z3G+xUNyUqupm8VN4QD8XsUpmTICobBQhFLs3MCRFwSQexjnzkjDDTJz/HNTfJGKsOD09o7gRdlLVKxrQw/JM/A2dsaDuMW6KqjmrOsE804eUUnucBnNRObfeMBUz+QneSynMSIysIAnZ3STUBRfHjuj/YgIg3uaN4h84PvFfrB9WOKwuG0QCkJFoIBtborg0y1vWnqf/Kp8EAy3lwr+IE6/t/5dHPtCp6uUxmT8O/yW4PHA2/RufQ8isazIt/a/IdVHMht8VaYJRv5d9OyiNL5Ohh9WkesJ3SPgv2tEpJU4z9b1IiN18i0Tk30H1+nuQKyQsTjX2nB6RnKIpNmNseQKIuMFvOt3MqvquseWtMKjiApUauFBRe4Xh3tzA0w0jSSOPfY6tOO7p6D2j1vsF8X2Bt+l6/NUNgyGE6mgWm0vAWkK0nk2n7t/1DSLTB0NemS5iQcYhl8x9sadIUGTtah/9pLEKMLDJkKYGOrABoU0ILA/R+ATv9zfk3sL8+FdhzckPg6XHRHlZPHT7CC+sdppijioSmnecS9mF/7kf/Qrv73UXGY6drdmV7TEXW3GqoINiN6VnLhVwXlBmKtKMm0njDnfPX1MHrY++ZObt+nqAlhZQy6LP6CL1U38Pk5yXA1+j14J4ZY1E+25heKQY95Zn3yHGnXxYy8A1ZKo+9jbihWhDuuZIrizN5QNid+QYtxEFJ7eod2U84bll21o=",
+					"X-Hcp-Workload-Identity-Provider": "iam/project/7b6b7db5-5e04-498c-a9a5-9a883b9462a4/service-principal/test/workload-identity-provider/aws",
+				},
+				Method: "POST",
+				URL:    "https://sts.us-east-1.amazonaws.com?Action=GetCallerIdentity&Version=2011-06-15",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+
+			// Set the env vars
+			if tt.env.region {
+				t.Setenv(awsEnvRegion, tt.region)
+			}
+			if tt.env.accessKeyID {
+				t.Setenv(awsEnvAccessKeyId, tt.accessKeyID)
+			}
+			if tt.env.secretAccessKey {
+				t.Setenv(awsEnvSecretAccessKey, tt.secretAccessKey)
+			}
+			if tt.env.securityToken {
+				t.Setenv(awsEnvSessionToken, tt.securityToken)
+			}
+
+			mockAWS := createAwsTestServer(t, tt.rolename, tt.region, tt.accessKeyID, tt.secretAccessKey, tt.securityToken, tt.imdsv2SessionToken)
+			client := mockAWS.server.Client()
+			transport, ok := client.Transport.(*http.Transport)
+			r.True(ok)
+			transport.Proxy = func(req *http.Request) (*url.URL, error) {
+				url, err := url.Parse(fmt.Sprintf("%s%s", mockAWS.server.URL, req.URL.Path))
+				return url, err
+			}
+
+			// Create the AWS CredSource
+			ac := &AWSCredentialSource{
+				IMDSv2: tt.v2,
+				now:    testNow,
+				client: client,
+			}
+			out, err := ac.getCallerIdentityReq(tt.wip)
+			r.NoError(err)
+			r.Equal(tt.want.URL, out.URL)
+			r.Equal(tt.want.Method, out.Method)
+			r.EqualValues(tt.want.Headers, out.Headers)
+		})
+	}
+}
+
+type testAwsServer struct {
+	t        *testing.T
+	server   *httptest.Server
+	rolename string
+	region   string
+
+	accessKey       string
+	secretAccessKey string
+	securityToken   string
+
+	imdsv2SessionToken string
+}
+
+func createAwsTestServer(t *testing.T, rolename, region, accessKey, secretAccessKey, securityToken, imdsv2SessionToken string) *testAwsServer {
+	aws := &testAwsServer{
+		rolename:           rolename,
+		region:             region,
+		accessKey:          accessKey,
+		secretAccessKey:    secretAccessKey,
+		securityToken:      securityToken,
+		imdsv2SessionToken: imdsv2SessionToken,
+	}
+
+	aws.server = httptest.NewTLSServer(aws)
+	t.Cleanup(aws.server.Close)
+	return aws
+}
+
+func (aws *testAwsServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	validateSessionToken := func(r *http.Request) {
+		if aws.imdsv2SessionToken != "" {
+			headerValue := r.Header.Get(awsIMDSv2SessionTokenHeader)
+			if headerValue != aws.imdsv2SessionToken {
+				aws.t.Errorf("%q = \n%q\n want \n%q", awsIMDSv2SessionTokenHeader, headerValue, aws.imdsv2SessionToken)
+			}
+		}
+	}
+
+	validateSessionTTL := func(r *http.Request) {
+		if aws.imdsv2SessionToken != "" {
+			headerValue := r.Header.Get(awsIMDSv2SessionTtlHeader)
+			if headerValue != awsIMDSv2SessionTtl {
+				aws.t.Errorf("%q = \n%q\n want \n%q", awsIMDSv2SessionTtlHeader, headerValue, awsIMDSv2SessionTtl)
+			}
+		}
+	}
+
+	switch p := r.URL.Path; p {
+	case "/latest/meta-data/iam/security-credentials":
+		validateSessionToken(r)
+		w.Write([]byte(aws.rolename))
+	case fmt.Sprintf("/latest/meta-data/iam/security-credentials/%s", aws.rolename):
+		validateSessionToken(r)
+
+		// Build the response
+		creds := map[string]string{}
+		if aws.accessKey != "" {
+			creds["AccessKeyId"] = aws.accessKey
+		}
+		if aws.secretAccessKey != "" {
+			creds["SecretAccessKey"] = aws.secretAccessKey
+		}
+		if aws.imdsv2SessionToken != "" && aws.securityToken != "" {
+			creds["Token"] = aws.securityToken
+		}
+
+		jsonCredentials, _ := json.Marshal(creds)
+		w.Write(jsonCredentials)
+	case "/latest/meta-data/placement/region":
+		validateSessionToken(r)
+		w.Write([]byte(aws.region))
+	case "/latest/api/token":
+		validateSessionTTL(r)
+		w.Write([]byte(aws.imdsv2SessionToken))
+	}
+}

--- a/auth/workload/env.go
+++ b/auth/workload/env.go
@@ -26,8 +26,8 @@ func (ec *EnvironmentVariableCredentialSource) Validate() error {
 }
 
 // token retrieves the token from the environment variable
-func (e *EnvironmentVariableCredentialSource) token() (string, error) {
-	value, ok := os.LookupEnv(e.Var)
+func (ec *EnvironmentVariableCredentialSource) token() (string, error) {
+	value, ok := os.LookupEnv(ec.Var)
 	if !ok {
 		return "", fmt.Errorf("environment variable not found")
 	}
@@ -35,5 +35,5 @@ func (e *EnvironmentVariableCredentialSource) token() (string, error) {
 		return "", fmt.Errorf("environment variable value is empty")
 	}
 
-	return e.CredentialFormat.get([]byte(value))
+	return ec.CredentialFormat.get([]byte(value))
 }

--- a/auth/workload/env.go
+++ b/auth/workload/env.go
@@ -1,0 +1,39 @@
+package workload
+
+import (
+	"fmt"
+	"os"
+)
+
+// EnvironmentVariableCredentialSource sources credentials by reading the
+// specified environment variable.
+type EnvironmentVariableCredentialSource struct {
+	// Var sources the external credential value from the given environment variable.
+	Var string `json:"var"`
+
+	// CredentialFormat configures how the credentials are extracted from the environment
+	// variable value.
+	CredentialFormat
+}
+
+// Validate validates the config.
+func (ec *EnvironmentVariableCredentialSource) Validate() error {
+	if ec.Var == "" {
+		return fmt.Errorf("environment variable must be specified")
+	}
+
+	return ec.CredentialFormat.Validate()
+}
+
+// token retrieves the token from the environment variable
+func (e *EnvironmentVariableCredentialSource) token() (string, error) {
+	value, ok := os.LookupEnv(e.Var)
+	if !ok {
+		return "", fmt.Errorf("environment variable not found")
+	}
+	if value == "" {
+		return "", fmt.Errorf("environment variable value is empty")
+	}
+
+	return e.CredentialFormat.get([]byte(value))
+}

--- a/auth/workload/env_test.go
+++ b/auth/workload/env_test.go
@@ -49,10 +49,6 @@ func TestEnvironmentVariableCredentialSource_Validate(t *testing.T) {
 }
 
 func TestEnvironmentVariableCredentialSource_token(t *testing.T) {
-	type fields struct {
-		Var              string
-		CredentialFormat CredentialFormat
-	}
 	tests := []struct {
 		name        string
 		ec          *EnvironmentVariableCredentialSource

--- a/auth/workload/env_test.go
+++ b/auth/workload/env_test.go
@@ -1,0 +1,150 @@
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEnvironmentVariableCredentialSource_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		ec     *EnvironmentVariableCredentialSource
+		errStr string
+	}{
+		{
+			name:   "empty cred source",
+			ec:     &EnvironmentVariableCredentialSource{},
+			errStr: "environment variable must be specified",
+		},
+		{
+			name: "valid cred source",
+			ec: &EnvironmentVariableCredentialSource{
+				Var:              "env-var",
+				CredentialFormat: CredentialFormat{},
+			},
+			errStr: "",
+		},
+		{
+			name: "invalid formatter",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "env-var",
+				CredentialFormat: CredentialFormat{
+					Type: "bad",
+				},
+			},
+			errStr: "format type must either be",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.ec.Validate()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestEnvironmentVariableCredentialSource_token(t *testing.T) {
+	type fields struct {
+		Var              string
+		CredentialFormat CredentialFormat
+	}
+	tests := []struct {
+		name        string
+		ec          *EnvironmentVariableCredentialSource
+		envVarName  string
+		envVarValue string
+		want        string
+		errStr      string
+	}{
+		{
+			name: "basic",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+			},
+			envVarName:  "MY_VAR",
+			envVarValue: "token",
+			want:        "token",
+			errStr:      "",
+		},
+		{
+			name: "not found",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+			},
+			envVarName:  "MY_OTHER_VAR",
+			envVarValue: "token",
+			want:        "",
+			errStr:      "environment variable not found",
+		},
+		{
+			name: "empty env var",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+			},
+			envVarName:  "MY_VAR",
+			envVarValue: "",
+			want:        "",
+			errStr:      "environment variable value is empty",
+		},
+		{
+			name: "json",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			envVarName:  "MY_VAR",
+			envVarValue: `{"access_token": "token"}`,
+			want:        "token",
+			errStr:      "",
+		},
+		{
+			name: "bad json",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			envVarName:  "MY_VAR",
+			envVarValue: `"access_token": "token"}`,
+			want:        "",
+			errStr:      "failed to unmarshal json value",
+		},
+		{
+			name: "missing json key",
+			ec: &EnvironmentVariableCredentialSource{
+				Var: "MY_VAR",
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/missing",
+				},
+			},
+			envVarName:  "MY_VAR",
+			envVarValue: `{"access_token": "token"}`,
+			want:        "",
+			errStr:      "Object has no key 'missing'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Set the env var
+			t.Setenv(tt.envVarName, tt.envVarValue)
+			got, err := tt.ec.token()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}

--- a/auth/workload/file.go
+++ b/auth/workload/file.go
@@ -1,0 +1,51 @@
+package workload
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// FileCredentialSource sources credentials by reading the file at the given
+// path.
+type FileCredentialSource struct {
+	// Path sources the external credential by reading the value from the
+	// specified file path.
+	Path string `json:"path"`
+
+	// CredentialFormat configures how the credentials are extracted from the file.
+	CredentialFormat
+}
+
+// Validate validates the config.
+func (fc *FileCredentialSource) Validate() error {
+	if fc.Path == "" {
+		return fmt.Errorf("path must be set")
+	}
+
+	return fc.CredentialFormat.Validate()
+}
+
+// token retrieves the token from the specified file
+func (f *FileCredentialSource) token() (string, error) {
+	credFile, err := os.Open(f.Path)
+	if err != nil {
+		return "", fmt.Errorf("failed to open credential file %q", f.Path)
+	}
+	defer credFile.Close()
+
+	// Read the file but limit the size we read to a MB
+	credBytes, err := ioutil.ReadAll(io.LimitReader(credFile, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("failed to read credential file: %v", err)
+	}
+
+	if len(credBytes) == 0 {
+		return "", fmt.Errorf("credential file is empty")
+	}
+
+	value := bytes.TrimSpace(credBytes)
+	return f.CredentialFormat.get(value)
+}

--- a/auth/workload/file.go
+++ b/auth/workload/file.go
@@ -29,10 +29,10 @@ func (fc *FileCredentialSource) Validate() error {
 }
 
 // token retrieves the token from the specified file
-func (f *FileCredentialSource) token() (string, error) {
-	credFile, err := os.Open(f.Path)
+func (fc *FileCredentialSource) token() (string, error) {
+	credFile, err := os.Open(fc.Path)
 	if err != nil {
-		return "", fmt.Errorf("failed to open credential file %q", f.Path)
+		return "", fmt.Errorf("failed to open credential file %q", fc.Path)
 	}
 	defer credFile.Close()
 
@@ -47,5 +47,5 @@ func (f *FileCredentialSource) token() (string, error) {
 	}
 
 	value := bytes.TrimSpace(credBytes)
-	return f.CredentialFormat.get(value)
+	return fc.CredentialFormat.get(value)
 }

--- a/auth/workload/file_test.go
+++ b/auth/workload/file_test.go
@@ -1,0 +1,146 @@
+package workload
+
+import (
+	"io"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFileCredentialSource_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		fc     *FileCredentialSource
+		errStr string
+	}{
+		{
+			name:   "empty cred source",
+			fc:     &FileCredentialSource{},
+			errStr: "path must be set",
+		},
+		{
+			name: "valid cred source",
+			fc: &FileCredentialSource{
+				Path:             "~/token.json",
+				CredentialFormat: CredentialFormat{},
+			},
+			errStr: "",
+		},
+		{
+			name: "invalid formatter",
+			fc: &FileCredentialSource{
+				Path: "/folder/token.json",
+				CredentialFormat: CredentialFormat{
+					Type: "bad",
+				},
+			},
+			errStr: "format type must either be",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fc.Validate()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestFileCredentialSource_token(t *testing.T) {
+	tests := []struct {
+		name        string
+		fc          *FileCredentialSource
+		fileContent string
+		want        string
+		errStr      string
+	}{
+		{
+			name:        "basic",
+			fc:          &FileCredentialSource{},
+			fileContent: "token",
+			want:        "token",
+			errStr:      "",
+		},
+		{
+			name: "not found",
+			fc: &FileCredentialSource{
+				Path: "unknown_file",
+			},
+			fileContent: "token",
+			want:        "",
+			errStr:      "failed to open credential file",
+		},
+		{
+			name:        "empty file",
+			fc:          &FileCredentialSource{},
+			fileContent: "",
+			want:        "",
+			errStr:      "credential file is empty",
+		},
+		{
+			name: "json",
+			fc: &FileCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			fileContent: `{"access_token": "token"}`,
+			want:        "token",
+			errStr:      "",
+		},
+		{
+			name: "bad json",
+			fc: &FileCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			fileContent: `"access_token": "token"}`,
+			want:        "",
+			errStr:      "failed to unmarshal json value",
+		},
+		{
+			name: "missing json key",
+			fc: &FileCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/missing",
+				},
+			},
+			fileContent: `{"access_token": "token"}`,
+			want:        "",
+			errStr:      "Object has no key 'missing'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Create a temp file with the given value
+			f, err := ioutil.TempFile("", "file_cred_source")
+			require.NoError(err)
+			_, err = io.Copy(f, strings.NewReader(tt.fileContent))
+			require.NoError(err)
+
+			// Configure the credential source to use the temp file
+			if tt.fc.Path == "" {
+				tt.fc.Path = f.Name()
+			}
+
+			got, err := tt.fc.token()
+			if tt.errStr == "" {
+				require.NoError(err)
+				require.Equal(tt.want, got)
+			} else {
+				require.ErrorContains(err, tt.errStr)
+			}
+		})
+	}
+}

--- a/auth/workload/format.go
+++ b/auth/workload/format.go
@@ -1,0 +1,89 @@
+package workload
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/xeipuuv/gojsonpointer"
+)
+
+const (
+	// FormatTypeValue indicates that the value itself contains the access_token
+	FormatTypeValue = "value"
+
+	// FormatTypeJSON indicates that the response is a JSON payload that
+	// contains the access_token.
+	FormatTypeJSON = "json"
+)
+
+// CredentialFormat configures how to extract the credential from the source
+// value. It supports either treating the entire response as the value or
+// extracting a particular field from a JSON response.
+type CredentialFormat struct {
+	// Type is either "text" or "json". When not provided "text" type is assumed.
+	Type string `json:"format_type"`
+
+	// SubjectCredentialPointer is a JSON pointer that indicates how to access
+	// the subject credential.
+	SubjectCredentialPointer string `json:"subject_cred_pointer"`
+}
+
+// Validate validates the format configuration.
+func (cf CredentialFormat) Validate() error {
+	credType := cf.Type
+	if credType == "" {
+		credType = FormatTypeValue
+	}
+
+	if credType != FormatTypeValue && credType != FormatTypeJSON {
+		return fmt.Errorf("format type must either be %q or %q", FormatTypeValue, FormatTypeJSON)
+	}
+
+	if credType == FormatTypeValue && cf.SubjectCredentialPointer != "" {
+		return fmt.Errorf("subject credential pointer must not be set with format type %q", FormatTypeValue)
+	}
+
+	if credType == FormatTypeJSON {
+		if cf.SubjectCredentialPointer == "" {
+			return fmt.Errorf("subject credential pointer must be set with format type %q", FormatTypeJSON)
+		}
+
+		if _, err := gojsonpointer.NewJsonPointer(cf.SubjectCredentialPointer); err != nil {
+			return fmt.Errorf("subject credential pointer is invalid: %v", err)
+		}
+	}
+
+	return nil
+}
+
+// get extracts the subject token from the passed response value based on the
+// CredentialFormat configuration.
+func (cf CredentialFormat) get(value []byte) (string, error) {
+	if cf.Type == FormatTypeValue || cf.Type == "" {
+		return string(value), nil
+	}
+
+	// Unmarshal the JSON value
+	jsonData := make(map[string]interface{})
+	if err := json.Unmarshal(value, &jsonData); err != nil {
+		return "", fmt.Errorf("failed to unmarshal json value: %v", err)
+	}
+
+	jsonp, err := gojsonpointer.NewJsonPointer(cf.SubjectCredentialPointer)
+	if err != nil {
+		return "", fmt.Errorf("subject credential pointer is invalid: %v", err)
+	}
+
+	// Retrieve the access token using the JSON pointer
+	val, _, err := jsonp.Get(jsonData)
+	if err != nil {
+		return "", err
+	}
+
+	cred, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("credential must be a string; got %T", val)
+	}
+
+	return cred, nil
+}

--- a/auth/workload/format_test.go
+++ b/auth/workload/format_test.go
@@ -1,0 +1,157 @@
+package workload
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialFormat_Validate(t *testing.T) {
+	tests := []struct {
+		name                     string
+		Type                     string
+		SubjectCredentialPointer string
+		errStr                   string
+	}{
+		{
+			name:   "default",
+			errStr: "",
+		},
+		{
+			name:                     "default type with subject token",
+			SubjectCredentialPointer: "/field",
+			errStr:                   "subject credential pointer must not be set with format type",
+		},
+		{
+			name:   "value valid",
+			Type:   FormatTypeValue,
+			errStr: "",
+		},
+		{
+			name:                     "value type with subject token",
+			Type:                     FormatTypeValue,
+			SubjectCredentialPointer: "/field",
+			errStr:                   "subject credential pointer must not be set with format type",
+		},
+		{
+			name:                     "json valid",
+			Type:                     FormatTypeJSON,
+			SubjectCredentialPointer: "/token",
+			errStr:                   "",
+		},
+		{
+			name:                     "json and no subject token field name",
+			Type:                     FormatTypeJSON,
+			SubjectCredentialPointer: "",
+			errStr:                   "subject credential pointer must be set",
+		},
+		{
+			name:                     "json invalid pointer",
+			Type:                     FormatTypeJSON,
+			SubjectCredentialPointer: "token!",
+			errStr:                   "subject credential pointer is invalid: JSON pointer must be empty or start with a \"/\"",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cf := CredentialFormat{
+				Type:                     tt.Type,
+				SubjectCredentialPointer: tt.SubjectCredentialPointer,
+			}
+			err := cf.Validate()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestCredentialFormat_get(t *testing.T) {
+	tests := []struct {
+		name   string
+		format CredentialFormat
+		value  []byte
+		want   string
+		errStr string
+	}{
+		{
+			name:   "default value",
+			format: CredentialFormat{},
+			value:  []byte("hello, world!"),
+			want:   "hello, world!",
+			errStr: "",
+		},
+		{
+			name: "value",
+			format: CredentialFormat{
+				Type: FormatTypeValue,
+			},
+			value:  []byte("hello, world!"),
+			want:   "hello, world!",
+			errStr: "",
+		},
+		{
+			name: "invalid json",
+			format: CredentialFormat{
+				Type:                     FormatTypeJSON,
+				SubjectCredentialPointer: "/good",
+			},
+			value:  []byte(`{"good": "token"`),
+			want:   "",
+			errStr: "failed to unmarshal json value: unexpected end of JSON input",
+		},
+		{
+			name: "json top level",
+			format: CredentialFormat{
+				Type:                     FormatTypeJSON,
+				SubjectCredentialPointer: "/good",
+			},
+			value:  []byte(`{"good": "token"}`),
+			want:   "token",
+			errStr: "",
+		},
+		{
+			name: "json not found key",
+			format: CredentialFormat{
+				Type:                     FormatTypeJSON,
+				SubjectCredentialPointer: "/unknown",
+			},
+			value:  []byte(`{"good": "token"}`),
+			want:   "",
+			errStr: "Object has no key 'unknown'",
+		},
+		{
+			name: "json deep pointer",
+			format: CredentialFormat{
+				Type:                     FormatTypeJSON,
+				SubjectCredentialPointer: "/top/inner/deeper",
+			},
+			value:  []byte(`{"top": {"inner": {"deeper": "token"}}}`),
+			want:   "token",
+			errStr: "",
+		},
+		{
+			name: "json non-string value",
+			format: CredentialFormat{
+				Type:                     FormatTypeJSON,
+				SubjectCredentialPointer: "/top",
+			},
+			value:  []byte(`{"top": true}`),
+			want:   "",
+			errStr: "credential must be a string; got bool",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.format.get(tt.value)
+			if tt.errStr == "" {
+				require.NoError(t, err)
+				require.Equal(t, tt.want, got)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}

--- a/auth/workload/provider.go
+++ b/auth/workload/provider.go
@@ -1,0 +1,260 @@
+package workload
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+	"golang.org/x/oauth2"
+)
+
+// IdentityProviderConfig configures how to source a workload credential and
+// exchange it for an HCP Service Principal access token using Workload Identity
+// Federation.
+type IdentityProviderConfig struct {
+	// ProviderResourceName is the resource name of the workload identity
+	// provider to exchange the access_token with.
+	ProviderResourceName string `json:"provider_resource_name"`
+
+	// File sources the subject credential from a file.
+	File *FileCredentialSource `json:"file"`
+
+	// EnvironmentVariable sources the subject credential from an environment
+	// variable.
+	EnvironmentVariable *EnvironmentVariableCredentialSource `json:"env"`
+
+	// URL sources the subject credential by making a HTTP request to the
+	// provided URL.
+	URL *URLCredentialSource `json:"url"`
+
+	// AWS uses the IMDS endpoint to retrieve the AWS Caller Identity.
+	AWS *AWSCredentialSource `json:"aws"`
+}
+
+// Validate validates the config.
+func (c *IdentityProviderConfig) Validate() error {
+	if c == nil {
+		return fmt.Errorf("workload identity provider config must not be nil")
+	}
+
+	if c.ProviderResourceName == "" {
+		return fmt.Errorf("workload identity provider resource name must be set")
+	}
+
+	set := 0
+	if c.File != nil {
+		set++
+		if err := c.File.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if c.EnvironmentVariable != nil {
+		set++
+		if err := c.EnvironmentVariable.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if c.URL != nil {
+		set++
+		if err := c.URL.Validate(); err != nil {
+			return err
+		}
+	}
+
+	if c.AWS != nil {
+		set++
+	}
+
+	if set == 0 {
+		return fmt.Errorf("a credential source must be configured")
+	} else if set > 1 {
+		return fmt.Errorf("only one credential source may be configured")
+	}
+
+	return nil
+}
+
+// Provider sources a workload token and exchanges it for a HCP service
+// principal access token. It implements the oauth2.TokenSource interface.
+type Provider struct {
+	// wipResourceName is the resource name of the workload identity provider to
+	// exchange the workload subject token with.
+	wipResourceName string
+
+	// jwtProvider is set if the credential source retrieves an opaque JWT
+	// token.
+	jwtProvider jwtAccessTokenProvider
+
+	// awsProvider is set if the credential source is AWS.
+	awsProvider awsCallerIDProvider
+
+	// apiInfo retrieves information on how to access the HCP API
+	apiInfo hcpAPIInfo
+
+	// httpClient is used to make requests to the exchange-token endpoint. It
+	// should be retrieved using the getHTTPClient method.
+	httpClient     *http.Client
+	httpClientOnce *sync.Once
+}
+
+// New takes an IdentityProviderConfig and returns a Provider or an error if the
+// configuration is invalid. The provider can then be used as an auth source
+// when creating the HCP Configuration.
+func New(c *IdentityProviderConfig) (*Provider, error) {
+	if err := c.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Construct the provider
+	p := &Provider{
+		wipResourceName: c.ProviderResourceName,
+		awsProvider:     c.AWS,
+		httpClientOnce:  new(sync.Once),
+	}
+	if c.URL != nil {
+		p.jwtProvider = c.URL
+	} else if c.File != nil {
+		p.jwtProvider = c.File
+	} else if c.EnvironmentVariable != nil {
+		p.jwtProvider = c.EnvironmentVariable
+	}
+
+	return p, nil
+}
+
+// SetAPI configures the HCP API to use. This will be called by the
+// WithWorkloadIdentity helper.
+func (p *Provider) SetAPI(info hcpAPIInfo) {
+	p.apiInfo = info
+}
+
+// Token implements the oauth2.TokenSource interface. It retrieves the workload
+// subject token using the configured credential source and then exchanges it
+// for the HCP SP access_token.
+func (p *Provider) Token() (*oauth2.Token, error) {
+	if p.apiInfo == nil {
+		return nil, fmt.Errorf("API info must be set before Token() can be called")
+	}
+
+	// Get the token
+	exchangeReq := &exchangeTokenRequest{}
+	if p.jwtProvider != nil {
+		token, err := p.jwtProvider.token()
+		if err != nil {
+			return nil, err
+		}
+		exchangeReq.JwtToken = token
+	} else {
+		callerIdentityReq, err := p.awsProvider.getCallerIdentityReq(p.wipResourceName)
+		if err != nil {
+			return nil, err
+		}
+		exchangeReq.AwsGetCallerIDToken = callerIdentityReq
+	}
+
+	exchangeBytes, err := json.Marshal(exchangeReq)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall exchange token request: %v", err)
+	}
+
+	// Make the exchange request
+	resp, err := p.getHTTPClient().Post(p.exchangeTokenRequestURL(), "application/json", bytes.NewReader(exchangeBytes))
+	if err != nil {
+		return nil, fmt.Errorf("invalid response from exchange token endpoint: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the body
+	body, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+
+	// Check that we got a valid response
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return nil, fmt.Errorf("exchange token status code %d: %s", c, body)
+	}
+
+	var exchangeResp exchangeTokenResponse
+	err = json.Unmarshal(body, &exchangeResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body from exchange token endpoint: %v", err)
+	}
+
+	token := &oauth2.Token{
+		AccessToken: exchangeResp.AccessToken,
+		Expiry:      time.Now().Add(time.Duration(exchangeResp.ExpiresIn) * time.Second),
+	}
+
+	return token, nil
+}
+
+// exchangeTokenRequestURL returns the URL for the exchange-token endpoint.
+func (p *Provider) exchangeTokenRequestURL() string {
+	u := &url.URL{
+		Scheme: "https",
+		Host:   p.apiInfo.APIAddress(),
+		Path:   fmt.Sprintf("/2019-12-10/%s/exchange-token", p.wipResourceName),
+	}
+
+	return u.String()
+}
+
+// getHTTPClient returns the HTTP Client to use when dialing the HCP API.
+func (p *Provider) getHTTPClient() *http.Client {
+	p.httpClientOnce.Do(func() {
+		transport := cleanhttp.DefaultPooledTransport()
+		transport.TLSClientConfig = p.apiInfo.APITLSConfig().Clone()
+		p.httpClient = &http.Client{
+			Transport: transport,
+			Timeout:   10 * time.Second,
+		}
+	})
+	return p.httpClient
+}
+
+// exchangeRequest is used to exchange an external subject token for a service
+// principal token
+type exchangeTokenRequest struct {
+	AwsGetCallerIDToken *callerIdentityRequest `json:"aws_get_caller_id_token,omitempty"`
+	JwtToken            string                 `json:"jwt_token,omitempty"`
+}
+
+// exchangeTokenResponse is the response from the exchange token endpoint.
+type exchangeTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	ExpiresIn   int    `json:"expires_in"`
+}
+
+// jwtAccessTokenProvider is the interface for providers that return a jwt
+// access token.
+type jwtAccessTokenProvider interface {
+	// token returns the access_token or an error
+	token() (string, error)
+}
+
+// awsCallerIDProvider is the interface for an AWS provider that return a Caller
+// Identity Request.
+type awsCallerIDProvider interface {
+	// getCallerIdentityReq returns the signed AWS GetCallerIdentity request.
+	getCallerIdentityReq(wipResourceName string) (*callerIdentityRequest, error)
+}
+
+// hcpAPIInfo returns the API information for accessing the HCP API.
+type hcpAPIInfo interface {
+	// APIAddress will return the HCP API address (<hostname>[:port]).
+	APIAddress() string
+
+	// APITLSConfig will return the API TLS configuration.
+	APITLSConfig() *tls.Config
+}

--- a/auth/workload/provider_test.go
+++ b/auth/workload/provider_test.go
@@ -13,11 +13,6 @@ import (
 )
 
 func TestProvider_New(t *testing.T) {
-	type fields struct {
-		URL              string
-		Headers          map[string]string
-		CredentialFormat CredentialFormat
-	}
 	tests := []struct {
 		name   string
 		ipc    *IdentityProviderConfig

--- a/auth/workload/provider_test.go
+++ b/auth/workload/provider_test.go
@@ -1,0 +1,202 @@
+package workload
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_New(t *testing.T) {
+	type fields struct {
+		URL              string
+		Headers          map[string]string
+		CredentialFormat CredentialFormat
+	}
+	tests := []struct {
+		name   string
+		ipc    *IdentityProviderConfig
+		errStr string
+	}{
+		{
+			name:   "nil config",
+			ipc:    nil,
+			errStr: "workload identity provider config must not be nil",
+		},
+		{
+			name:   "empty config",
+			ipc:    &IdentityProviderConfig{},
+			errStr: "workload identity provider resource name must be set",
+		},
+		{
+			name:   "no credential source",
+			ipc:    &IdentityProviderConfig{ProviderResourceName: "iam/test"},
+			errStr: "a credential source must be configured",
+		},
+		{
+			name: "more than one credential source",
+			ipc: &IdentityProviderConfig{
+				ProviderResourceName: "iam/test",
+				File: &FileCredentialSource{
+					Path: "test",
+				},
+				AWS: &AWSCredentialSource{
+					IMDSv2: false,
+				},
+			},
+			errStr: "only one credential source may be configured",
+		},
+		{
+			name: "calls validate on cred source",
+			ipc: &IdentityProviderConfig{
+				ProviderResourceName: "iam/test",
+				File: &FileCredentialSource{
+					Path: "",
+				},
+			},
+			errStr: "path must be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.ipc)
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestProvider_Token_JWT(t *testing.T) {
+	require := require.New(t)
+
+	// Set the credential in an env var
+	envVar := "test"
+	cred := "example_cred"
+	t.Setenv(envVar, cred)
+
+	// Create the provider
+	pname := "iam/project/123/service-principal/bar/workload-identity-provider/baz"
+	c := &IdentityProviderConfig{
+		ProviderResourceName: pname,
+		EnvironmentVariable: &EnvironmentVariableCredentialSource{
+			Var: envVar,
+		},
+	}
+	p, err := New(c)
+	require.NoError(err)
+
+	// Create an HTTP test server
+	hcpToken := "hcp_ftw"
+	hcpTokenExpiration := 42
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(fmt.Sprintf("/2019-12-10/%s/exchange-token", pname), r.URL.Path)
+		var req exchangeTokenRequest
+		require.NoError(json.NewDecoder(r.Body).Decode(&req))
+		require.Equal(cred, req.JwtToken)
+		require.Nil(req.AwsGetCallerIDToken)
+
+		resp := &exchangeTokenResponse{
+			AccessToken: hcpToken,
+			ExpiresIn:   hcpTokenExpiration,
+		}
+		require.NoError(json.NewEncoder(w).Encode(resp))
+	}))
+	defer ts.Close()
+
+	// Create the API Config
+	hcpAPI := &hcpAPI{
+		apiAddress: ts.Listener.Addr().String(),
+	}
+	transport, ok := ts.Client().Transport.(*http.Transport)
+	require.True(ok)
+	hcpAPI.tlsConfig = transport.TLSClientConfig.Clone()
+	p.SetAPI(hcpAPI)
+
+	// Call token exchange
+	token, err := p.Token()
+	require.NoError(err)
+	require.Equal(hcpToken, token.AccessToken)
+	require.WithinDuration(time.Now().Add(time.Duration(hcpTokenExpiration)*time.Second), token.Expiry, 100*time.Millisecond)
+}
+
+func TestProvider_Token_AWS(t *testing.T) {
+	require := require.New(t)
+
+	// Create the provider
+	pname := "iam/project/123/service-principal/bar/workload-identity-provider/baz"
+	c := &IdentityProviderConfig{
+		ProviderResourceName: pname,
+		AWS:                  &AWSCredentialSource{},
+	}
+	p, err := New(c)
+	require.NoError(err)
+
+	// Swap the actual AWS credential source for a test one
+	id := &callerIdentityRequest{
+		Headers: map[string]string{"hello": "world!"},
+		Method:  "PUT",
+		URL:     "https://sts.us-east1.awsapi.com/",
+	}
+	p.awsProvider = &mockAWS{id: id}
+
+	// Create an HTTP test server
+	hcpToken := "hcp_ftw"
+	hcpTokenExpiration := 42
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(fmt.Sprintf("/2019-12-10/%s/exchange-token", pname), r.URL.Path)
+		var req exchangeTokenRequest
+		require.NoError(json.NewDecoder(r.Body).Decode(&req))
+		require.NotNil(req.AwsGetCallerIDToken)
+		require.EqualValues(id.Headers, req.AwsGetCallerIDToken.Headers)
+		require.Equal(id.Method, req.AwsGetCallerIDToken.Method)
+		require.Equal(id.URL, req.AwsGetCallerIDToken.URL)
+		resp := &exchangeTokenResponse{
+			AccessToken: hcpToken,
+			ExpiresIn:   hcpTokenExpiration,
+		}
+		require.NoError(json.NewEncoder(w).Encode(resp))
+	}))
+	defer ts.Close()
+
+	// Create the API Config
+	hcpAPI := &hcpAPI{
+		apiAddress: ts.Listener.Addr().String(),
+	}
+	transport, ok := ts.Client().Transport.(*http.Transport)
+	require.True(ok)
+	hcpAPI.tlsConfig = transport.TLSClientConfig.Clone()
+	p.SetAPI(hcpAPI)
+
+	// Call token exchange
+	token, err := p.Token()
+	require.NoError(err)
+	require.Equal(hcpToken, token.AccessToken)
+	require.WithinDuration(time.Now().Add(time.Duration(hcpTokenExpiration)*time.Second), token.Expiry, 100*time.Millisecond)
+}
+
+type mockAWS struct {
+	id *callerIdentityRequest
+}
+
+func (aws *mockAWS) getCallerIdentityReq(_ string) (*callerIdentityRequest, error) {
+	return aws.id, nil
+}
+
+type hcpAPI struct {
+	// apiAddress is the test HCP API address (<hostname>[:port]).
+	apiAddress string
+
+	// tlsConfig is the test tls config
+	tlsConfig *tls.Config
+}
+
+func (a *hcpAPI) APIAddress() string        { return a.apiAddress }
+func (a *hcpAPI) APITLSConfig() *tls.Config { return a.tlsConfig }

--- a/auth/workload/url.go
+++ b/auth/workload/url.go
@@ -1,0 +1,84 @@
+package workload
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/hashicorp/go-cleanhttp"
+)
+
+// URLCredentialSource sources credentials by making an HTTP request to the
+// given URL.
+type URLCredentialSource struct {
+	// URL reads the credentials by invoking the given URL with the headers.
+	URL string `json:"url"`
+
+	// Headers are included when invoking the given URL.
+	Headers map[string]string `json:"headers"`
+
+	// CredentialFormat configures how the credentials are extracted from the HTTP
+	// response body.
+	CredentialFormat
+}
+
+// Validate validates the config.
+func (uc *URLCredentialSource) Validate() error {
+	if uc.URL == "" {
+		return fmt.Errorf("non-empty URL is required")
+	}
+
+	_, err := url.Parse(uc.URL)
+	if err != nil {
+		return fmt.Errorf("failed to parse url %q: %v", uc.URL, err)
+	}
+
+	return uc.CredentialFormat.Validate()
+}
+
+// token retrieves the token by making a HTTP request to the configured URL.
+func (uc *URLCredentialSource) token() (string, error) {
+	// Build the request
+	req, err := http.NewRequest("GET", uc.URL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed creating an HTTP request for workload access_token: %v", err)
+	}
+
+	// Make the request with a timeout
+	reqCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req = req.WithContext(reqCtx)
+
+	// Add the headers to the request
+	for key, val := range uc.Headers {
+		req.Header.Add(key, val)
+	}
+
+	// Make the request
+	client := cleanhttp.DefaultClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("invalid response retrieving token: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the response
+	respBody, err := ioutil.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("failed reading body in subject token response: %v", err)
+	}
+	if c := resp.StatusCode; c < 200 || c > 299 {
+		return "", fmt.Errorf("subject token response failed with status code %d: %s", c, respBody)
+	}
+
+	if len(respBody) == 0 {
+		return "", fmt.Errorf("response body is empty")
+	}
+
+	// Extract the value
+	return uc.CredentialFormat.get(respBody)
+}

--- a/auth/workload/url_test.go
+++ b/auth/workload/url_test.go
@@ -59,11 +59,6 @@ func TestURLCredentialSource_Validate(t *testing.T) {
 }
 
 func TestURLCredentialSource_token(t *testing.T) {
-	type fields struct {
-		URL              string
-		Headers          map[string]string
-		CredentialFormat CredentialFormat
-	}
 	tests := []struct {
 		name     string
 		uc       *URLCredentialSource
@@ -137,7 +132,8 @@ func TestURLCredentialSource_token(t *testing.T) {
 
 			// Create an HTTP test server
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.Write([]byte(tt.respBody))
+				_, err := w.Write([]byte(tt.respBody))
+				require.NoError(err)
 			}))
 			defer ts.Close()
 

--- a/auth/workload/url_test.go
+++ b/auth/workload/url_test.go
@@ -1,0 +1,158 @@
+package workload
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestURLCredentialSource_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		uc     *URLCredentialSource
+		errStr string
+	}{
+		{
+			name:   "empty cred source",
+			uc:     &URLCredentialSource{},
+			errStr: "non-empty URL is required",
+		},
+		{
+			name: "valid url",
+			uc: &URLCredentialSource{
+				URL:              "https://localhost:4200/token",
+				CredentialFormat: CredentialFormat{},
+			},
+			errStr: "",
+		},
+		{
+			name: "invalid url",
+			uc: &URLCredentialSource{
+				URL:              "badUrl/123",
+				CredentialFormat: CredentialFormat{},
+			},
+			errStr: "",
+		},
+		{
+			name: "invalid formatter",
+			uc: &URLCredentialSource{
+				URL: "/folder/token.json",
+				CredentialFormat: CredentialFormat{
+					Type: "bad",
+				},
+			},
+			errStr: "format type must either be",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.uc.Validate()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestURLCredentialSource_token(t *testing.T) {
+	type fields struct {
+		URL              string
+		Headers          map[string]string
+		CredentialFormat CredentialFormat
+	}
+	tests := []struct {
+		name     string
+		uc       *URLCredentialSource
+		respBody string
+		want     string
+		errStr   string
+	}{
+		{
+			name:     "basic",
+			uc:       &URLCredentialSource{},
+			respBody: "token",
+			want:     "token",
+			errStr:   "",
+		},
+		{
+			name: "not found",
+			uc: &URLCredentialSource{
+				URL: "http://unknown-url-path.localhost.com",
+			},
+			respBody: "token",
+			want:     "",
+			errStr:   "invalid response retrieving token",
+		},
+		{
+			name:     "empty response",
+			uc:       &URLCredentialSource{},
+			respBody: "",
+			want:     "",
+			errStr:   "response body is empty",
+		},
+		{
+			name: "json response",
+			uc: &URLCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			respBody: `{"access_token": "token"}`,
+			want:     "token",
+			errStr:   "",
+		},
+		{
+			name: "bad json",
+			uc: &URLCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/access_token",
+				},
+			},
+			respBody: `"access_token": "token"}`,
+			want:     "",
+			errStr:   "failed to unmarshal json value",
+		},
+		{
+			name: "missing json key",
+			uc: &URLCredentialSource{
+				CredentialFormat: CredentialFormat{
+					Type:                     FormatTypeJSON,
+					SubjectCredentialPointer: "/missing",
+				},
+			},
+			respBody: `{"access_token": "token"}`,
+			want:     "",
+			errStr:   "Object has no key 'missing'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+
+			// Create an HTTP test server
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Write([]byte(tt.respBody))
+			}))
+			defer ts.Close()
+
+			// Configure the credential source to use the test server url
+			if tt.uc.URL == "" {
+				tt.uc.URL = ts.URL
+			}
+
+			got, err := tt.uc.token()
+			if tt.errStr == "" {
+				require.NoError(err)
+				require.Equal(tt.want, got)
+			} else {
+				require.ErrorContains(err, tt.errStr)
+			}
+		})
+	}
+}

--- a/config/with.go
+++ b/config/with.go
@@ -9,7 +9,9 @@ import (
 	"net/url"
 
 	"github.com/hashicorp/hcp-sdk-go/auth"
+	"github.com/hashicorp/hcp-sdk-go/auth/workload"
 	"github.com/hashicorp/hcp-sdk-go/profile"
+	"golang.org/x/oauth2"
 )
 
 // WithClientCredentials credentials is an option that can be used to set
@@ -19,6 +21,18 @@ func WithClientCredentials(clientID, clientSecret string) HCPConfigOption {
 		config.clientCredentialsConfig.ClientID = clientID
 		config.clientCredentialsConfig.ClientSecret = clientSecret
 
+		return nil
+	}
+}
+
+// WithWorkloadIdentity exchanges a workload identity provider credentials for
+// an HCP Service Principal token. The Workload Identity Provider can be AWS or
+// any OIDC based identity provider.
+func WithWorkloadIdentity(provider *workload.Provider) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		// Store the provider as the token source
+		config.tokenSource = oauth2.ReuseTokenSource(nil, provider)
+		provider.SetAPI(config)
 		return nil
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db
 	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/stretchr/testify v1.8.2
+	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb
 	golang.org/x/net v0.8.0
 	golang.org/x/oauth2 v0.6.0
 )

--- a/go.sum
+++ b/go.sum
@@ -155,6 +155,8 @@ github.com/xdg-go/scram v1.0.2/go.mod h1:1WAq6h33pAW+iRreB34OORO2Nf7qel3VV3fjBj+
 github.com/xdg-go/scram v1.1.1/go.mod h1:RaEWvsqvNKKvBPvcKeFjrG2cJqOkHTiyTpzz23ni57g=
 github.com/xdg-go/stringprep v1.0.2/go.mod h1:8F9zXuvzgwmyT5DUm4GUfZGDdT3W+LCvS6+da4O5kxM=
 github.com/xdg-go/stringprep v1.0.3/go.mod h1:W3f5j4i+9rC0kuIEJL0ky1VpHXQU3ocBgklLGvcBnW8=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
+github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d/go.mod h1:rHwXgn7JulP+udvsHwJoVG1YGAP6VLg4y9I5dyZdqmA=
 go.mongodb.org/mongo-driver v1.7.3/go.mod h1:NqaYOwnXWr5Pm7AOpO5QFxKJ503nbMse/R79oO62zWg=
 go.mongodb.org/mongo-driver v1.7.5/go.mod h1:VXEWRZ6URJIkUq2SCAyapmhH0ZLRBP+FT4xhp5Zvxng=


### PR DESCRIPTION
### :hammer_and_wrench: Description

Add the ability to authenticate using workload identity federation. This allows the SDK to source a workload credential and exchange it for an HCP service principal credential. The workload credential may be sourced from a:

* environment variable
* a file
* a HTTP request
* AWS IMDS 

### :link: External Links

RFC HCP-363 and HCP-378.

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [X] Tests added?
- [ ] Docs updated?

#### Manual Testing

1. On PRDE created a SP and a identity provider pointing at my PRDE AWS account
2. Compiled and ran the following binary on PRDE (tried both IMDSv2: true and false)

```
package main

import (
	"crypto/tls"
	"log"

	"github.com/hashicorp/hcp-sdk-go/auth/workload"
	"github.com/hashicorp/hcp-sdk-go/config"
)

func main() {
	providerConfig := &workload.IdentityProviderConfig{
		ProviderResourceName: "iam/project/58967b2f-bc68-464e-8fb7-8e7d65b377f8/service-principal/test/workload-identity-provider/aws",
		AWS: &workload.AWSCredentialSource{
			IMDSv2: true,
		},
	}

	p, err := workload.New(providerConfig)
	if err != nil {
		log.Fatal(err)
	}

	_, err = config.NewHCPConfig(config.WithWorkloadIdentity(p), config.WithAPI("XXX.hashicorp.services", &tls.Config{}))
	if err != nil {
		log.Fatal(err)
	}

	t, err := p.Token()
	if err != nil {
		log.Fatal(err)
	}

	log.Printf("token: %#v", t)
}
```

3. Printed a valid access token.