### PR TITLE
Add Credential File support

### DIFF
--- a/.changelog/200.txt
+++ b/.changelog/200.txt
@@ -1,0 +1,4 @@
+```release-note:feature
+SDK can authenticate using a credential file. The credential file can specify
+service principal credentials or workload identity provided credentials.
+```

--- a/auth/cred_file.go
+++ b/auth/cred_file.go
@@ -1,0 +1,184 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/hcp-sdk-go/auth/workload"
+)
+
+const (
+	// EnvHCPCredFile is the environment variable that sets the HCP Credential
+	// File location.
+	EnvHCPCredFile = "HCP_CRED_FILE"
+
+	// CredentialFileName is the file name for the HCP credential file.
+	CredentialFileName = "cred_file.json"
+
+	// CredentialFileSchemeServicePrincipal is the credential file scheme value
+	// that indicates service principal credentials should be used to
+	// authenticate to HCP.
+	CredentialFileSchemeServicePrincipal = "service_principal_creds"
+
+	// CredentialFileSchemeWorkload is the credential file scheme value
+	// that indicates workload identity credentials should be used to
+	// authenticate to HCP.
+	CredentialFileSchemeWorkload = "workload"
+)
+
+var (
+	// testDefaultHCPCredFilePath is the the default HCP Credential File location during
+	// tests. The test should set its value.
+	testDefaultHCPCredFilePath = ""
+)
+
+// CredentialFile stores information required to authenticate to HCP APIs. It
+// supports various authentication schemes, such as service principal
+type CredentialFile struct {
+	// ProjectID captures the project ID of the service principal. It may be blank.
+	ProjectID string `json:"project_id"`
+
+	// Scheme is the authentication scheme. It may be one of: service_principal_creds, workload.
+	Scheme string `json:"scheme"`
+
+	// Workload configures the workload identity provider to exchange tokens
+	// with.
+	Workload *workload.IdentityProviderConfig `json:"workload"`
+
+	// Oauth configures authentication via Oauth.
+	Oauth *OauthConfig `json:"oauth"`
+}
+
+// OauthConfig configures authentication based on OAuth credentials.
+type OauthConfig struct {
+	// ClientID is the client id of an HCP Service Principal
+	ClientID string `json:"client_id"`
+
+	// SecretID is the secret id of an HCP Service Principal
+	SecretID string `json:"secret_id"`
+}
+
+// Validate validates the CredentialFile
+func (c *CredentialFile) Validate() error {
+	if c == nil {
+		return nil
+	}
+
+	if c.Scheme == CredentialFileSchemeServicePrincipal {
+		if c.Oauth == nil {
+			return fmt.Errorf("oauth config must be set when scheme is %q", CredentialFileSchemeServicePrincipal)
+		}
+
+		if err := c.Oauth.Validate(); err != nil {
+			return fmt.Errorf("oauth: %v", err)
+		}
+	} else if c.Scheme == CredentialFileSchemeWorkload {
+		if c.Workload == nil {
+			return fmt.Errorf("workload config must be set when scheme is %q", CredentialFileSchemeWorkload)
+		}
+
+		if err := c.Workload.Validate(); err != nil {
+			return fmt.Errorf("workload: %v", err)
+		}
+	} else {
+		return fmt.Errorf("scheme must be one of: %q, %q", CredentialFileSchemeServicePrincipal, CredentialFileSchemeWorkload)
+	}
+
+	if c.Workload != nil && c.Oauth != nil {
+		return fmt.Errorf("only one of oauth or workload may be set")
+	}
+
+	return nil
+}
+
+// Validate validates the OauthConfig
+func (o *OauthConfig) Validate() error {
+	if o.ClientID == "" || o.SecretID == "" {
+		return fmt.Errorf("both client_id and secret_id must be set")
+	}
+
+	return nil
+}
+
+// ReadCredentialFile returns the credential file at the given path.
+func ReadCredentialFile(path string) (*CredentialFile, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read credential file: %w", err)
+	}
+
+	var f CredentialFile
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal credential file: %v", err)
+	}
+
+	return &f, f.Validate()
+
+}
+
+// GetDefaultCredentialFile returns the credential file by searching the default
+// credential file location or by using the credential file environment variable
+// to look for an override. If no credential file is found, a nil value will be
+// returned with no error set.
+func GetDefaultCredentialFile() (*CredentialFile, error) {
+	p, err := getCredentialFilePath()
+	if err != nil {
+		return nil, fmt.Errorf("failed to find credential file: %v", err)
+	}
+
+	// Read the credential file, but if no credential file is found, suppress
+	// the erorr.
+	cf, err := ReadCredentialFile(p)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+
+	return cf, err
+}
+
+// getCredentialFilePath returns the credential file path, first looking for an
+// overriding environment variable and then falling back to the default file
+// location.
+func getCredentialFilePath() (string, error) {
+	if testDefaultHCPCredFilePath != "" {
+		return testDefaultHCPCredFilePath, nil
+	}
+
+	if p, ok := os.LookupEnv(EnvHCPCredFile); ok {
+		return p, nil
+	}
+
+	// Get the user's home directory.
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve user's home directory path: %v", err)
+	}
+
+	p := filepath.Join(userHome, defaultDirectory, CredentialFileName)
+	return p, nil
+}
+
+// WriteDefaultCredentialFile writes the credential file to the default
+// credential file location or to the value of EnvHCPCredFile if set.
+func WriteDefaultCredentialFile(cf *CredentialFile) error {
+	p, err := getCredentialFilePath()
+	if err != nil {
+		return err
+	}
+
+	return WriteCredentialFile(p, cf)
+}
+
+// WriteCredentialFile writes the given credential file to the path.
+func WriteCredentialFile(path string, cf *CredentialFile) error {
+	data, err := json.MarshalIndent(cf, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(path, data, directoryPermissions)
+}

--- a/auth/cred_file_test.go
+++ b/auth/cred_file_test.go
@@ -1,0 +1,249 @@
+package auth
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"testing"
+
+	"github.com/hashicorp/hcp-sdk-go/auth/workload"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialFile_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		cf     *CredentialFile
+		errStr string
+	}{
+		{
+			name: "valid oauth",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeServicePrincipal,
+				Oauth: &OauthConfig{
+					ClientID: "abc",
+					SecretID: "def",
+				},
+			},
+			errStr: "",
+		},
+		{
+			name: "valid workload",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeWorkload,
+				Workload: &workload.IdentityProviderConfig{
+					ProviderResourceName: "iam/test",
+					AWS:                  &workload.AWSCredentialSource{},
+				},
+			},
+			errStr: "",
+		},
+		{
+			name: "mismatched scheme",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeServicePrincipal,
+				Workload: &workload.IdentityProviderConfig{
+					ProviderResourceName: "iam/test",
+					AWS:                  &workload.AWSCredentialSource{},
+				},
+			},
+			errStr: "oauth config must be set when scheme is \"service_principal_creds\"",
+		},
+		{
+			name: "invalid oauth",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeServicePrincipal,
+				Oauth: &OauthConfig{
+					ClientID: "abc",
+					SecretID: "",
+				},
+			},
+			errStr: "oauth: both client_id and secret_id must be set",
+		},
+		{
+			name: "invalid workload",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeWorkload,
+				Workload: &workload.IdentityProviderConfig{
+					AWS: &workload.AWSCredentialSource{},
+				},
+			},
+			errStr: "workload: workload identity provider resource name must be set",
+		},
+		{
+			name: "both set",
+			cf: &CredentialFile{
+				ProjectID: "123",
+				Scheme:    CredentialFileSchemeWorkload,
+				Workload: &workload.IdentityProviderConfig{
+					ProviderResourceName: "iam/test",
+					AWS:                  &workload.AWSCredentialSource{},
+				},
+				Oauth: &OauthConfig{
+					ClientID: "abc",
+					SecretID: "def",
+				},
+			},
+			errStr: "only one of oauth or workload may be set",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.cf.Validate()
+			if tt.errStr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errStr)
+			}
+		})
+	}
+}
+
+func TestReadCredentialFile(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		r := require.New(t)
+		cf := &CredentialFile{
+			Scheme: CredentialFileSchemeServicePrincipal,
+			Oauth: &OauthConfig{
+				ClientID: "abc",
+				SecretID: "123",
+			},
+		}
+
+		f, err := ioutil.TempFile("", "")
+		r.NoError(err)
+		r.NoError(WriteCredentialFile(f.Name(), cf))
+
+		out, err := ReadCredentialFile(f.Name())
+		r.NoError(err)
+		r.EqualValues(cf, out)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		_, err := ReadCredentialFile(fmt.Sprintf("random-%d", rand.Int()))
+		require.Error(t, err)
+		require.ErrorContains(t, err, "failed to read credential file: open random")
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		r := require.New(t)
+		cf := &CredentialFile{
+			Scheme: CredentialFileSchemeServicePrincipal,
+			Oauth: &OauthConfig{
+				ClientID: "abc",
+			},
+		}
+
+		f, err := ioutil.TempFile("", "")
+		r.NoError(err)
+		r.NoError(WriteCredentialFile(f.Name(), cf))
+
+		_, err = ReadCredentialFile(f.Name())
+		r.ErrorContains(err, "oauth: both client_id and secret_id must be set")
+	})
+
+	t.Run("bad format", func(t *testing.T) {
+		r := require.New(t)
+		data, err := json.Marshal("hello, world!")
+		r.NoError(err)
+
+		f, err := ioutil.TempFile("", "")
+		r.NoError(err)
+
+		_, err = io.Copy(f, bytes.NewBuffer(data))
+		r.NoError(err)
+
+		_, err = ReadCredentialFile(f.Name())
+		r.ErrorContains(err, "failed to unmarshal credential file")
+	})
+}
+
+func TestGetDefaultCredentialFile(t *testing.T) {
+	t.Run("with env", func(t *testing.T) {
+		r := require.New(t)
+
+		cf := &CredentialFile{
+			Scheme: CredentialFileSchemeServicePrincipal,
+			Oauth: &OauthConfig{
+				ClientID: "abc",
+				SecretID: "123",
+			},
+		}
+
+		f, err := ioutil.TempFile("", "")
+		r.NoError(err)
+		r.NoError(WriteCredentialFile(f.Name(), cf))
+
+		t.Setenv(EnvHCPCredFile, f.Name())
+		out, err := GetDefaultCredentialFile()
+		r.NoError(err)
+		r.EqualValues(cf, out)
+	})
+
+	t.Run("without env", func(t *testing.T) {
+		r := require.New(t)
+
+		cf := &CredentialFile{
+			Scheme: CredentialFileSchemeServicePrincipal,
+			Oauth: &OauthConfig{
+				ClientID: "abc",
+				SecretID: "123",
+			},
+		}
+
+		f, err := ioutil.TempFile("", "")
+		r.NoError(err)
+		r.NoError(WriteCredentialFile(f.Name(), cf))
+
+		testDefaultHCPCredFilePath = f.Name()
+		out, err := GetDefaultCredentialFile()
+		testDefaultHCPCredFilePath = ""
+		r.NoError(err)
+		r.EqualValues(cf, out)
+	})
+}
+
+func Test_getCredentialFilePath(t *testing.T) {
+	t.Run("with env", func(t *testing.T) {
+		r := require.New(t)
+		cf := "test-path"
+		t.Setenv(EnvHCPCredFile, cf)
+		p, err := getCredentialFilePath()
+		r.NoError(err)
+		r.Equal(cf, p)
+	})
+
+	t.Run("without  env", func(t *testing.T) {
+		r := require.New(t)
+		p, err := getCredentialFilePath()
+		r.NoError(err)
+		r.Contains(p, CredentialFileName)
+	})
+}
+
+func Test_WriteCredentialFile(t *testing.T) {
+	r := require.New(t)
+	cf := &CredentialFile{
+		Scheme: CredentialFileSchemeServicePrincipal,
+		Oauth: &OauthConfig{
+			ClientID: "abc",
+			SecretID: "123",
+		},
+	}
+
+	f, err := ioutil.TempFile("", "")
+	r.NoError(err)
+	r.NoError(WriteCredentialFile(f.Name(), cf))
+
+	back, err := ReadCredentialFile(f.Name())
+	r.NoError(err)
+	r.EqualValues(cf, back)
+}

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -101,6 +101,9 @@ type hcpConfig struct {
 
 	// suppressLogging is an option to prevent this SDK from printing anything
 	suppressLogging bool
+
+	// credentialFile is the credential file to use.
+	credentialFile *auth.CredentialFile
 }
 
 func (c *hcpConfig) Profile() *profile.UserProfile {

--- a/config/new.go
+++ b/config/new.go
@@ -130,7 +130,7 @@ func NewHCPConfig(opts ...HCPConfigOption) (HCPConfig, error) {
 // default file location).
 // 3. Interactive session.
 func (c *hcpConfig) setTokenSource() error {
-	// token source is already explicitely configured.
+	// token source is already explicitly configured.
 	if c.tokenSource != nil {
 		return nil
 	}

--- a/config/with.go
+++ b/config/with.go
@@ -116,7 +116,8 @@ func WithAuth(authURL string, tlsConfig *tls.Config) HCPConfigOption {
 	}
 }
 
-// WithOAuth2ClientID credentials is an option that can be used to provide a custom OAuth2 Client ID.
+// WithOAuth2ClientID credentials is an option that can be used to provide a
+// custom OAuth2 Client ID.
 //
 // An alternative OAuth2 ClientID can be provided, if none is provided the
 // default OAuth2 Client ID will be used.
@@ -152,8 +153,9 @@ func WithProfile(p *profile.UserProfile) HCPConfigOption {
 	}
 }
 
-// WithoutBrowserLogin disables the automatic opening of the browser login if no valid auth method is found
-// instead force the return of a typed error for users to catch.
+// WithoutBrowserLogin disables the automatic opening of the browser login if no
+// valid auth method is found instead force the return of a typed error for
+// users to catch.
 func WithoutBrowserLogin() HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.noBrowserLogin = true
@@ -161,11 +163,31 @@ func WithoutBrowserLogin() HCPConfigOption {
 	}
 }
 
-// WithoutLogging disables this SDK from printing of any kind, this is necessary since there is not a consistent logger
-// that is used throughout the project so a log level option is not sufficient.
+// WithoutLogging disables this SDK from printing of any kind, this is necessary
+// since there is not a consistent logger that is used throughout the project so
+// a log level option is not sufficient.
 func WithoutLogging() HCPConfigOption {
 	return func(config *hcpConfig) error {
 		config.suppressLogging = true
 		return nil
+	}
+}
+
+// WithCredentialFile sets the given credential file to be used as an
+// authentication source.
+func WithCredentialFile(cf *auth.CredentialFile) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		config.credentialFile = cf
+		return config.credentialFile.Validate()
+	}
+}
+
+// WithCredentialFilePath will search for a credential file at the given path to
+// be used as an authentication source.
+func WithCredentialFilePath(p string) HCPConfigOption {
+	return func(config *hcpConfig) error {
+		cf, err := auth.ReadCredentialFile(p)
+		config.credentialFile = cf
+		return err
 	}
 }

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/hashicorp/hcp-sdk-go/auth"
 	"github.com/hashicorp/hcp-sdk-go/profile"
-	"github.com/stretchr/testify/require"
 	requirepkg "github.com/stretchr/testify/require"
 )
 
@@ -192,6 +191,6 @@ func TestWith_CredentialFilePath(t *testing.T) {
 	t.Run("not found", func(t *testing.T) {
 		// Exercise
 		config := &hcpConfig{}
-		require.Error(t, apply(config, WithCredentialFilePath(fmt.Sprintf("random-%d", rand.Int()))))
+		requirepkg.Error(t, apply(config, WithCredentialFilePath(fmt.Sprintf("random-%d", rand.Int()))))
 	})
 }

--- a/config/with_test.go
+++ b/config/with_test.go
@@ -5,10 +5,14 @@ package config
 
 import (
 	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
 	"testing"
 
 	"github.com/hashicorp/hcp-sdk-go/auth"
 	"github.com/hashicorp/hcp-sdk-go/profile"
+	"github.com/stretchr/testify/require"
 	requirepkg "github.com/stretchr/testify/require"
 )
 
@@ -133,4 +137,61 @@ func TestWithout_BrowserLogin(t *testing.T) {
 
 	// Ensure  browser login is disabled
 	require.True(config.noBrowserLogin)
+}
+
+func TestWith_CredentialFile(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Exercise with an invalid credential file
+	config := &hcpConfig{}
+	cf := &auth.CredentialFile{
+		ProjectID: "123",
+	}
+	require.Error(apply(config, WithCredentialFile(cf)))
+
+	// Exercise with a valid credential file
+	cf = &auth.CredentialFile{
+		ProjectID: "123",
+		Scheme:    auth.CredentialFileSchemeServicePrincipal,
+		Oauth: &auth.OauthConfig{
+			ClientID: "123",
+			SecretID: "456",
+		},
+	}
+	require.NoError(apply(config, WithCredentialFile(cf)))
+
+	// Ensure the cred file is set
+	require.Equal(cf, config.credentialFile)
+}
+
+func TestWith_CredentialFilePath(t *testing.T) {
+	t.Run("found", func(t *testing.T) {
+		require := requirepkg.New(t)
+
+		// Write the cred file
+		cf := &auth.CredentialFile{
+			ProjectID: "123",
+			Scheme:    auth.CredentialFileSchemeServicePrincipal,
+			Oauth: &auth.OauthConfig{
+				ClientID: "123",
+				SecretID: "456",
+			},
+		}
+		f, err := ioutil.TempFile("", "")
+		require.NoError(err)
+		require.NoError(auth.WriteCredentialFile(f.Name(), cf))
+
+		// Exercise
+		config := &hcpConfig{}
+		require.NoError(apply(config, WithCredentialFilePath(f.Name())))
+
+		// Ensure the cred file is set
+		require.Equal(cf, config.credentialFile)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		// Exercise
+		config := &hcpConfig{}
+		require.Error(t, apply(config, WithCredentialFilePath(fmt.Sprintf("random-%d", rand.Int()))))
+	})
 }


### PR DESCRIPTION
### :hammer_and_wrench: Description

SDK can authenticate using a credential file. The credential file can specify service principal credentials or workload identity provided credentials.

### :link: External Links

HCP-378 RFC

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [X] Tests added?
- [ ] Docs updated?

Ran the following test program:

```
package main

import (
	"crypto/tls"
	"log"

	"github.com/hashicorp/hcp-sdk-go/config"
)

func main() {
	cfg, err := config.NewHCPConfig(config.WithAPI("alex01-XXX.hashicorp.services", &tls.Config{}))
	if err != nil {
		log.Fatal(err)
	}

	t, err := cfg.Token()
	if err != nil {
		log.Fatal(err)
	}

	log.Printf("token: %#v", t)
}
```

I wrote a valid config file to `~/.config/hcp/cred_file.json`:

```
{
  "scheme": "workload",
  "workload": {
    "provider_resource_name": "iam/project/58967b2f-bc68-464e-8fb7-8e7d65b377f8/service-principal/test/workload-identity-provider/aws",
    "aws": {
      "imds_v2": true
    }
  }
}
```


Running the program printed a valid token.

I then moved the cred_file.json to `cred_file2.json` and ran the program again. It tried to retrieve the token via the browser as expected.

I then ran `HCP_CRED_FILE=~/.config/hcp/cred_file2.json ./aws` and it again printed a valid token from workload identity federation.