### PR TITLE
Update sync-internal-and-public.yml

### DIFF
--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -41,7 +41,9 @@ jobs:
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp -a internal/scripts temp/scripts
-          cp -a internal/cmd/transform-swagger temp/cmd/transform-swagger
+          mkdir temp/cmd
+          mkdir temp/cmd/transform-swagger
+          cp -a internal/cmd/transform-swagger/* temp/cmd/transform-swagger/
           cp internal/README.md temp/README.md
           cp internal/catalog-info.yaml temp/catalog-info.yaml
           cp internal/mkdocs.yml temp/mkdocs.yml

--- a/.github/workflows/sync-internal-and-public.yml
+++ b/.github/workflows/sync-internal-and-public.yml
@@ -41,8 +41,7 @@ jobs:
           cp -a internal/clients temp/clients
           cp -a internal/docs temp/docs
           cp -a internal/scripts temp/scripts
-          mkdir temp/cmd
-          mkdir temp/cmd/transform-swagger
+          mkdir -p temp/cmd/transform-swagger
           cp -a internal/cmd/transform-swagger/* temp/cmd/transform-swagger/
           cp internal/README.md temp/README.md
           cp internal/catalog-info.yaml temp/catalog-info.yaml


### PR DESCRIPTION
### :hammer_and_wrench: Description

Ensure the transform-swagger directory gets copied over correctly when syncing the public and internal repos.
