### PR TITLE
Retract v0.76.0

### DIFF
--- a/.changelog/223.txt
+++ b/.changelog/223.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Mark v0.76.0 as retracted due to backward incompatible cloud-network models and clients introduced by swagger mis-configuration.
+```

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,8 @@ go 1.18
 
 retract v0.26.0 // Pushed accidentally
 
+retract v0.76.0 // Backward-incompatible cloud-network client/models
+
 require (
 	github.com/go-openapi/errors v0.20.4
 	github.com/go-openapi/runtime v0.26.0


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

<!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 
version of a service SDK was added, what are the key new features or breaking changes? -->
* Due to faulty swagger generation of public spec for cloud-network, backward-incompatible changes were introduced and included in v0.76.0.
* Updates go.mod to retract v.0.76.0
* This commit fixed the incompatibility issue: https://github.com/hashicorp/hcp-sdk-go/commit/7b4027d7083d329b75397e340e2b878a2553d627

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?