### PR TITLE
Fix default browser boolean semantics

### DIFF
--- a/.changelog/266.txt
+++ b/.changelog/266.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixed default browser opening logic.
+```

--- a/auth/browser.go
+++ b/auth/browser.go
@@ -23,29 +23,29 @@ import (
 type browserLogin struct {
 	oauthConfig *oauth2.Config
 
-	// Wether to open a browser in an external window or not.
-	openBrowser bool
+	// Wether to open the default browser in an external window.
+	noDefaultBrowser bool
 }
 
 // NewBrowserLogin will return an oauth2.TokenSource that will return a Token from an interactive browser login.
-func NewBrowserLogin(oauthConfig *oauth2.Config, openBrowser bool) *browserLogin {
+func NewBrowserLogin(oauthConfig *oauth2.Config, noDefaultBrowser bool) *browserLogin {
 	return &browserLogin{
-		oauthConfig: oauthConfig,
-		openBrowser: openBrowser,
+		oauthConfig:      oauthConfig,
+		noDefaultBrowser: noDefaultBrowser,
 	}
 }
 
 // Token will return an oauth2.Token retrieved from an interactive browser login.
 func (b *browserLogin) Token() (*oauth2.Token, error) {
 	browser := &oauthBrowser{}
-	return browser.GetTokenFromBrowser(context.Background(), b.oauthConfig, b.openBrowser)
+	return browser.GetTokenFromBrowser(context.Background(), b.oauthConfig, b.noDefaultBrowser)
 }
 
 // oauthBrowser implements the Browser interface using the real OAuth2 login flow.
 type oauthBrowser struct{}
 
 // GetTokenFromBrowser opens a browser window for the user to log in and handles the OAuth2 flow to obtain a token.
-func (b *oauthBrowser) GetTokenFromBrowser(ctx context.Context, conf *oauth2.Config, openBrowser bool) (*oauth2.Token, error) {
+func (b *oauthBrowser) GetTokenFromBrowser(ctx context.Context, conf *oauth2.Config, noDefaultBrowser bool) (*oauth2.Token, error) {
 	// Prepare the /authorize request with randomly generated state, offline access option, and audience
 	aud := "https://api.hashicorp.cloud"
 	opt := oauth2.SetAuthURLParam("audience", aud)
@@ -57,14 +57,14 @@ func (b *oauthBrowser) GetTokenFromBrowser(ctx context.Context, conf *oauth2.Con
 	defer signal.Stop(sigintCh)
 
 	// Launch a request to HCP's authorization endpoint.
-	if openBrowser {
+	if noDefaultBrowser {
+		colorstring.Printf("[bold][yellow]Please open the following URL in your browser and follow the instructions to authenticate:\n%s\n", authzURL)
+	} else {
 		colorstring.Printf("[bold][yellow]The default web browser has been opened at %s. Please continue the login in the web browser.\n", authzURL)
 
 		if err := open.Start(authzURL); err != nil {
 			return nil, fmt.Errorf("failed to open browser at URL %q: %w", authzURL, err)
 		}
-	} else {
-		colorstring.Printf("[bold][yellow]Please open the following URL in your browser and follow the instructions to authenticate:\n%s\n", authzURL)
 	}
 
 	// Start callback server

--- a/config/tokensource.go
+++ b/config/tokensource.go
@@ -143,7 +143,7 @@ func (c *hcpConfig) getTokenSource() (oauth2.TokenSource, sourceType, string, er
 
 	var loginTokenSource oauth2.TokenSource
 	if !c.noBrowserLogin {
-		loginTokenSource = auth.NewBrowserLogin(&c.oauth2Config, c.noDefaultBrowser)
+		loginTokenSource = auth.NewBrowserLogin(&c.oauth2Config, !c.noDefaultBrowser)
 	}
 
 	return loginTokenSource, sourceTypeLogin, "", nil

--- a/config/tokensource.go
+++ b/config/tokensource.go
@@ -143,7 +143,7 @@ func (c *hcpConfig) getTokenSource() (oauth2.TokenSource, sourceType, string, er
 
 	var loginTokenSource oauth2.TokenSource
 	if !c.noBrowserLogin {
-		loginTokenSource = auth.NewBrowserLogin(&c.oauth2Config, !c.noDefaultBrowser)
+		loginTokenSource = auth.NewBrowserLogin(&c.oauth2Config, c.noDefaultBrowser)
 	}
 
 	return loginTokenSource, sourceTypeLogin, "", nil


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

By default we should be opening the default browser.

This fixes a mistake introduced in #265 which inverts the expected behavior.

<!-- What code changed, and why? If an existing service SDK was updated, what functionality was added? If a new 
version of a service SDK was added, what are the key new features or breaking changes? -->

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?