### PR TITLE
Fix concurrency issues

### DIFF
--- a/.changelog/267.txt
+++ b/.changelog/267.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Fixes concurrency issues while using a browser based token.
+```


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

Fixes parallelism problem where multiple token exchange happen if the code is invoked by multiple go routine. The lock also act as a protector for the cached file on the filesystem.

The crash can be reproduced by simulating a slower than expected response from the oauth webserver with the the following patch

```
diff --git a/auth/browser.go b/auth/browser.go
index fc10933..8559cfe 100644
--- a/auth/browser.go
+++ b/auth/browser.go
@@ -87,6 +87,7 @@ func (b *oauthBrowser) GetTokenFromBrowser(ctx context.Context, conf *oauth2.Con
 			return nil, err
 		}
 
+		time.Sleep(time.Second * 4)
 		err = callbackEndpoint.server.Shutdown(context.Background())
 		if err != nil {
 			return nil, fmt.Errorf("failed to shutdown callback server: %w", err)
```

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?