### PR TITLE
Login auth: Add geography to the cached credential file

### DIFF
--- a/.changelog/296.txt
+++ b/.changelog/296.txt
@@ -1,0 +1,3 @@
+```release-note:bug
+Allow auth between switching HCP geographies
+```

--- a/auth/tokencache/cache.go
+++ b/auth/tokencache/cache.go
@@ -113,6 +113,9 @@ type cacheEntry struct {
 
 	// AccessTokenExpiry is when the access token will expire.
 	AccessTokenExpiry time.Time `json:"access_token_expiry,omitempty"`
+
+	// geography is the geography of the HCP that issues the tokens.
+	Geography string `json:"geography,omitempty"`
 }
 
 // token will convert the cacheEntry to an oauth2.Token.
@@ -125,10 +128,11 @@ func (entry *cacheEntry) token() *oauth2.Token {
 }
 
 // cacheEntryFromToken will convert an oauth2.Token to a cacheEntry
-func cacheEntryFromToken(token *oauth2.Token) *cacheEntry {
+func cacheEntryFromToken(token *oauth2.Token, geo string) *cacheEntry {
 	return &cacheEntry{
 		AccessToken:       token.AccessToken,
 		AccessTokenExpiry: token.Expiry,
 		RefreshToken:      token.RefreshToken,
+		Geography:         geo,
 	}
 }

--- a/auth/tokencache/cache_test.go
+++ b/auth/tokencache/cache_test.go
@@ -28,6 +28,7 @@ func TestCache_ExpiredTokenRemoval(t *testing.T) {
 	valid := cacheEntry{
 		AccessToken:       "access-token",
 		AccessTokenExpiry: time.Now().Add(1 * time.Minute),
+		Geography:         "US",
 	}
 
 	// Set cache entries for service principals

--- a/auth/tokencache/clear_test.go
+++ b/auth/tokencache/clear_test.go
@@ -28,7 +28,7 @@ func TestTokenCache_ClearLoginCache(t *testing.T) {
 	tokenSource := NewTestTokenSource("")
 
 	// Create the caching token source for logins
-	subject := NewLoginTokenSource(cacheFile, tokenSource, nil)
+	subject, _ := NewLoginTokenSource(cacheFile, tokenSource, nil, "us")
 
 	// Fetch the token once. It should get cached.
 	token, err := subject.Token()

--- a/auth/tokencache/login.go
+++ b/auth/tokencache/login.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/hashicorp/hcp-sdk-go/config/geography"
 	"golang.org/x/oauth2"
 )
 
@@ -20,13 +21,19 @@ func NewLoginTokenSource(
 	cacheFile string,
 	oauthTokenSource oauth2.TokenSource,
 	oauthConfig oAuth2Config,
-) oauth2.TokenSource {
+	geo string,
+) (oauth2.TokenSource, error) {
+	if !geography.ValidateGeo(geography.Geo(geo)) {
+		return nil, fmt.Errorf("login geography %s invalid. Supported: %v", geo, geography.Geographies)
+	}
+
 	return &cachingTokenSource{
 		cacheFile:        cacheFile,
 		sourceType:       sourceTypeLogin,
 		oauthTokenSource: oauthTokenSource,
 		oauthConfig:      oauthConfig,
-	}
+		geography:        geo,
+	}, nil
 }
 
 func (source *cachingTokenSource) loginToken(cachedTokens *cache) (*oauth2.Token, error) {
@@ -43,13 +50,16 @@ func (source *cachingTokenSource) loginToken(cachedTokens *cache) (*oauth2.Token
 		return nil, fmt.Errorf("failed to get new token: %w", err)
 	}
 
-	if hitEntry != nil && hitEntry.AccessToken == token.AccessToken {
+	// For backwards compatibility, if geography is not set in the cache entry,
+	// we force an update to store the geography in the cached file
+	if hitEntry != nil && hitEntry.AccessToken == token.AccessToken &&
+		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
 		// The cached entry was used,  the cache does not need to be updated
 		return token, nil
 	}
 
 	// Cache the new token
-	cachedTokens.Login = cacheEntryFromToken(token)
+	cachedTokens.Login = cacheEntryFromToken(token, source.geography)
 
 	// Write the cache back to the file
 	if err = cachedTokens.write(source.cacheFile); err != nil {

--- a/auth/tokencache/serviceprincipal.go
+++ b/auth/tokencache/serviceprincipal.go
@@ -41,7 +41,7 @@ func (source *cachingTokenSource) servicePrincipalToken(cachedTokens *cache) (*o
 	}
 
 	// Cache the new token
-	cachedTokens.ServicePrincipals[source.sourceIdentifier] = *cacheEntryFromToken(token)
+	cachedTokens.ServicePrincipals[source.sourceIdentifier] = *cacheEntryFromToken(token, source.geography)
 
 	// Write the cache back to the file
 	if err = cachedTokens.write(source.cacheFile); err != nil {

--- a/auth/tokencache/tokensource.go
+++ b/auth/tokencache/tokensource.go
@@ -37,6 +37,7 @@ type cachingTokenSource struct {
 	sourceIdentifier string
 	oauthTokenSource oauth2.TokenSource
 	oauthConfig      oAuth2Config
+	geography        string
 }
 
 // Token implements the oauth2.TokenSource interface. It will read cached tokens from a file and based on their validity
@@ -84,12 +85,16 @@ func (source *cachingTokenSource) getValidToken(hitEntry *cacheEntry) (*oauth2.T
 	}
 
 	// Return the access token if it is still valid for at least minTTL
-	if token != nil && token.Expiry.After(time.Now().Add(minTTL)) {
+	// and match the geography
+	if token != nil && token.Expiry.After(time.Now().Add(minTTL)) &&
+		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
 		return token, nil
 	}
 
 	// Try to refresh the token if it has a RefreshToken and an oauth config was provided
-	if token != nil && token.RefreshToken != "" && source.oauthConfig != nil {
+	// and match the geography
+	if token != nil && token.RefreshToken != "" && source.oauthConfig != nil &&
+		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
 		ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
 		defer cancel()
 
@@ -109,4 +114,26 @@ func (source *cachingTokenSource) getValidToken(hitEntry *cacheEntry) (*oauth2.T
 	}
 
 	return nil, fmt.Errorf("no valid credential source available")
+}
+
+// matchGeography checks if the cached geography matches the config geography.
+// If the cached geography is empty, it means that the cache was created before geography support was added,
+// so it will return false to force an update of the cache.
+//
+// TODO: remove sourceType once geography is set for service principal and workload tokens.
+func matchGeography(sourceType sourceType, cachedGeography string, configGeography string) bool {
+	if sourceType != sourceTypeLogin {
+		return true
+	}
+
+	// The cached file is prior to geography support,
+	// return false
+	if cachedGeography == "" {
+		return false
+	}
+
+	if cachedGeography != configGeography {
+		return false
+	}
+	return true
 }

--- a/auth/tokencache/workload.go
+++ b/auth/tokencache/workload.go
@@ -41,7 +41,7 @@ func (source *cachingTokenSource) workloadToken(cachedTokens *cache) (*oauth2.To
 	}
 
 	// Cache the new token
-	cachedTokens.Workloads[source.sourceIdentifier] = *cacheEntryFromToken(token)
+	cachedTokens.Workloads[source.sourceIdentifier] = *cacheEntryFromToken(token, source.geography)
 
 	// Write the cache back to the file
 	if err = cachedTokens.write(source.cacheFile); err != nil {

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -63,6 +63,9 @@ func configFromGeography(config *hcpConfig, geo geography.Geo) (*hcpConfig, erro
 	config.oauth2Config.Endpoint.AuthURL = geoConfig.AuthURL + AuthEndpointAuthPath
 	config.oauth2Config.Endpoint.TokenURL = geoConfig.AuthURL + AuthEndpointTokenPath
 
+	// geography config
+	config.geography = geo
+
 	return config, nil
 }
 

--- a/config/geography/geography.go
+++ b/config/geography/geography.go
@@ -34,3 +34,13 @@ type Config struct {
 	// SCADAAddress is the address of the production SCADA endpoint
 	SCADAAddress string
 }
+
+// ValidateGeo checks if the provided geography is valid
+func ValidateGeo(geo Geo) bool {
+	for _, g := range Geographies {
+		if g == geo {
+			return true
+		}
+	}
+	return false
+}

--- a/config/hcp.go
+++ b/config/hcp.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/hcp-sdk-go/auth/tokencache"
 	"github.com/hashicorp/hcp-sdk-go/auth/workload"
 	"github.com/hashicorp/hcp-sdk-go/config/files"
+	"github.com/hashicorp/hcp-sdk-go/config/geography"
 
 	"github.com/hashicorp/hcp-sdk-go/auth"
 	"github.com/hashicorp/hcp-sdk-go/profile"
@@ -90,6 +91,9 @@ type hcpConfig struct {
 	// apiTLSConfig is the TLS configuration for the HCP API. It can be set to
 	// nil if TLS should be disabled.
 	apiTLSConfig *tls.Config
+
+	// geography is the geographical region for the HCP API
+	geography geography.Geo
 
 	// scadaAddress is the address (<hostname>[:port]) of the SCADA endpoint.
 	scadaAddress string

--- a/config/tokensource.go
+++ b/config/tokensource.go
@@ -52,7 +52,10 @@ func (c *hcpConfig) setTokenSource() error {
 
 	switch sourceType {
 	case sourceTypeLogin:
-		c.tokenSource = tokencache.NewLoginTokenSource(cacheFile, tokenSource, &c.oauth2Config)
+		c.tokenSource, err = tokencache.NewLoginTokenSource(cacheFile, tokenSource, &c.oauth2Config, string(c.geography))
+		if err != nil {
+			return err
+		}
 	case sourceTypeServicePrincipal:
 		c.tokenSource = tokencache.NewServicePrincipalTokenSource(
 			cacheFile,

--- a/config/with.go
+++ b/config/with.go
@@ -22,7 +22,7 @@ import (
 // first due to its broad scope of modification to the config.
 func WithGeography(geo string) HCPConfigOption {
 	return func(config *hcpConfig) error {
-		config, err := configFromGeography(config, geography.Geo(geo))
+		_, err := configFromGeography(config, geography.Geo(geo))
 
 		return err
 	}


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

This PR adds `geography` information to the cached credential file for login auth. The cached credential file will look like

```json
{
  "login":
	{
  	"geography": "...",
  	"access_token": "...",
  	"refresh_token": "...",
  	"access_token_expires_in": "..."
	},
}
```

- Test for backward compability - `TestCachingTokenSource_Login_CompatibleWithNoGeography`
- Test for switching geographies - `TestCachingTokenSource_Login_SwitchGeography`

Note that this PR only enables geography for login auth. Follow-up PRs will be made for workload and service principal

### Test

Tested with terraform provider 

- Before
Switching geography will fail
```
HCP_GEOGRAPHY=us terraform apply

HCP_GEOGRAPHY=eu terraform apply

Error: unable to fetch organization list: [GET /resource-manager/2019-12-10/organizations][401] OrganizationService_List default {"details":null}
│ 
│   with provider["hashicorp.com/test/hcp"],
│   on main.tf line 18, in provider "hcp":
│   18: provider "hcp" {

```

- After

```
HCP_GEOGRAPHY=us terraform apply
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

HCP_GEOGRAPHY=eu terraform apply
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
```


### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.