### PR TITLE
Workload identity auth: Add geography to the cached credential file

### DIFF
--- a/auth/tokencache/login.go
+++ b/auth/tokencache/login.go
@@ -53,7 +53,7 @@ func (source *cachingTokenSource) loginToken(cachedTokens *cache) (*oauth2.Token
 	// For backwards compatibility, if geography is not set in the cache entry,
 	// we force an update to store the geography in the cached file
 	if hitEntry != nil && hitEntry.AccessToken == token.AccessToken &&
-		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
+		matchGeography(hitEntry.Geography, source.geography) {
 		// The cached entry was used,  the cache does not need to be updated
 		return token, nil
 	}

--- a/auth/tokencache/tokensource.go
+++ b/auth/tokencache/tokensource.go
@@ -122,9 +122,9 @@ func (source *cachingTokenSource) getValidToken(hitEntry *cacheEntry) (*oauth2.T
 //
 // TODO: remove sourceType once geography is set for service principal and workload tokens.
 func matchGeography(sourceType sourceType, cachedGeography string, configGeography string) bool {
-	if sourceType != sourceTypeLogin && sourceType != sourceTypeServicePrincipal {
-		return true
-	}
+	// if sourceType != sourceTypeLogin && sourceType != sourceTypeServicePrincipal {
+	// 	return true
+	// }
 
 	// The cached file is prior to geography support,
 	// return false

--- a/auth/tokencache/tokensource.go
+++ b/auth/tokencache/tokensource.go
@@ -87,14 +87,14 @@ func (source *cachingTokenSource) getValidToken(hitEntry *cacheEntry) (*oauth2.T
 	// Return the access token if it is still valid for at least minTTL
 	// and match the geography
 	if token != nil && token.Expiry.After(time.Now().Add(minTTL)) &&
-		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
+		matchGeography(hitEntry.Geography, source.geography) {
 		return token, nil
 	}
 
 	// Try to refresh the token if it has a RefreshToken and an oauth config was provided
 	// and match the geography
 	if token != nil && token.RefreshToken != "" && source.oauthConfig != nil &&
-		matchGeography(source.sourceType, hitEntry.Geography, source.geography) {
+		matchGeography(hitEntry.Geography, source.geography) {
 		ctx, cancel := context.WithTimeout(context.Background(), refreshTimeout)
 		defer cancel()
 
@@ -119,13 +119,7 @@ func (source *cachingTokenSource) getValidToken(hitEntry *cacheEntry) (*oauth2.T
 // matchGeography checks if the cached geography matches the config geography.
 // If the cached geography is empty, it means that the cache was created before geography support was added,
 // so it will return false to force an update of the cache.
-//
-// TODO: remove sourceType once geography is set for service principal and workload tokens.
-func matchGeography(sourceType sourceType, cachedGeography string, configGeography string) bool {
-	// if sourceType != sourceTypeLogin && sourceType != sourceTypeServicePrincipal {
-	// 	return true
-	// }
-
+func matchGeography(cachedGeography string, configGeography string) bool {
 	// The cached file is prior to geography support,
 	// return false
 	if cachedGeography == "" {

--- a/auth/tokencache/workload.go
+++ b/auth/tokencache/workload.go
@@ -8,6 +8,8 @@ import (
 	"log"
 
 	"golang.org/x/oauth2"
+
+	"github.com/hashicorp/hcp-sdk-go/config/geography"
 )
 
 const sourceTypeWorkload = sourceType("workload")
@@ -18,13 +20,18 @@ func NewWorkloadTokenSource(
 	cacheFile string,
 	providerResourceName string,
 	oauthTokenSource oauth2.TokenSource,
-) oauth2.TokenSource {
+	geo string,
+) (oauth2.TokenSource, error) {
+	if !geography.ValidateGeo(geography.Geo(geo)) {
+		return nil, fmt.Errorf("login geography %s invalid. Supported: %v", geo, geography.Geographies)
+	}
 	return &cachingTokenSource{
 		cacheFile:        cacheFile,
 		sourceIdentifier: providerResourceName,
 		sourceType:       sourceTypeWorkload,
 		oauthTokenSource: oauthTokenSource,
-	}
+		geography:        geo,
+	}, nil
 }
 
 func (source *cachingTokenSource) workloadToken(cachedTokens *cache) (*oauth2.Token, error) {

--- a/auth/tokencache/workload_test.go
+++ b/auth/tokencache/workload_test.go
@@ -30,17 +30,21 @@ func TestCachingTokenSource_Workloads(t *testing.T) {
 	tokenSourceB := NewTestTokenSource("b")
 
 	// Create the caching token sources for service principals
-	subjectA := NewWorkloadTokenSource(
+	subjectA, err := NewWorkloadTokenSource(
 		cacheFile,
 		"workload-a",
 		tokenSourceA,
+		"us",
 	)
+	require.NoError(err)
 
-	subjectB := NewWorkloadTokenSource(
+	subjectB, err := NewWorkloadTokenSource(
 		cacheFile,
 		"workload-b",
 		tokenSourceB,
+		"eu",
 	)
+	require.NoError(err)
 
 	// Fetch both tokens. They should get cached.
 	token, err := subjectA.Token()
@@ -50,6 +54,13 @@ func TestCachingTokenSource_Workloads(t *testing.T) {
 	token, err = subjectB.Token()
 	require.NoError(err)
 	require.Equal("access-token-b1", token.AccessToken)
+
+	// Verify geography is stored in the cache file
+	cachedTokens, err := readCache(cacheFile)
+	require.NoError(err)
+	require.NotNil(cachedTokens)
+	require.Equal("us", cachedTokens.Workloads["workload-a"].Geography)
+	require.Equal("eu", cachedTokens.Workloads["workload-b"].Geography)
 
 	// Fetch the tokens a second time. They should be returned from cache.
 	token, err = subjectA.Token()
@@ -80,4 +91,152 @@ func TestCachingTokenSource_Workloads(t *testing.T) {
 	token, err = subjectB.Token()
 	require.NoError(err)
 	require.Equal("access-token-b2", token.AccessToken)
+}
+
+// TestCachingTokenSource_Workloads_CompatibleWithNoGeography ensures that tokens
+// cached without a geography are still compatible with the current implementation
+// that requires a geography. This is needed to ensure backwards compatibility.
+func TestCachingTokenSource_Workloads_CompatibleWithNoGeography(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Create a temporary directory to hold the test files
+	testDirectory, err := os.MkdirTemp("", "test-caching-token-source-")
+	require.NoError(err)
+
+	// Compile the credential cache path
+	cacheFile := path.Join(testDirectory, ".config/hcp/creds-cache.json")
+
+	// Ensure the tests files are cleaned up
+	defer os.RemoveAll(cacheFile)
+
+	// Create a cached credentials without geography
+	cachedCredentials := &cache{
+		Workloads: map[string]cacheEntry{
+			"workload-a": {
+				AccessToken:       "access-token-a1",
+				AccessTokenExpiry: time.Now().Add(5 * time.Minute),
+				Geography:         "", // No geography set to simulate old cache file
+			},
+			"workload-b": {
+				AccessToken:       "access-token-b1",
+				AccessTokenExpiry: time.Now().Add(5 * time.Minute),
+				Geography:         "", // No geography set to simulate old cache file
+			},
+		},
+	}
+
+	err = cachedCredentials.write(cacheFile)
+	require.NoError(err)
+	// Verify geography is empty in the cache file
+	readCacheOld, err := readCache(cacheFile)
+	require.NoError(err)
+	require.Equal("", readCacheOld.Workloads["workload-a"].Geography)
+	require.Equal("", readCacheOld.Workloads["workload-b"].Geography)
+
+	// Create a test token sources
+	tokenSourceA := NewTestTokenSource("a")
+	tokenSourceB := NewTestTokenSource("b")
+
+	// Create the caching token sources for service principals
+	subjectA, err := NewWorkloadTokenSource(
+		cacheFile,
+		"workload-a",
+		tokenSourceA,
+		"us",
+	)
+	require.NoError(err)
+
+	subjectB, err := NewWorkloadTokenSource(
+		cacheFile,
+		"workload-b",
+		tokenSourceB,
+		"eu",
+	)
+	require.NoError(err)
+
+	// Fetch both tokens. They should get refreshed and cached.
+	token, err := subjectA.Token()
+	require.NoError(err)
+	require.Equal("access-token-a1", token.AccessToken)
+
+	token, err = subjectB.Token()
+	require.NoError(err)
+	require.Equal("access-token-b1", token.AccessToken)
+
+	// Verify geography is stored in the cache file
+	readCache, err := readCache(cacheFile)
+	require.NoError(err)
+	require.Equal("us", readCache.Workloads["workload-a"].Geography)
+	require.Equal("eu", readCache.Workloads["workload-b"].Geography)
+}
+
+// TestCachingTokenSource_Workload_SwitchGeography ensures that
+//   - switching the geography of a workload token source creates a new cache entry
+//     if the geography is changed.
+//   - existing cached token is not overwritten if the geography is the same.
+func TestCachingTokenSource_Workload_SwitchGeography(t *testing.T) {
+	require := requirepkg.New(t)
+
+	// Create a temporary directory to hold the test files
+	testDirectory, err := os.MkdirTemp("", "test-caching-token-source-")
+	require.NoError(err)
+
+	// Compile the credential cache path
+	cacheFile := path.Join(testDirectory, ".config/hcp/creds-cache.json")
+
+	// Ensure the tests files are cleaned up
+	defer os.RemoveAll(cacheFile)
+
+	// Create a test token sources
+	tokenSourceA := NewTestTokenSource("a")
+	tokenSourceB := NewTestTokenSource("b")
+
+	// Create the caching token sources for workloads
+	subjectA, err := NewWorkloadTokenSource(
+		cacheFile,
+		"workload-a",
+		tokenSourceA,
+		"us",
+	)
+	require.NoError(err)
+
+	subjectB, err := NewWorkloadTokenSource(
+		cacheFile,
+		"workload-b",
+		tokenSourceB,
+		"us",
+	)
+	require.NoError(err)
+
+	// Fetch both tokens. They should get cached.
+	token, err := subjectA.Token()
+	require.NoError(err)
+	require.Equal("access-token-a1", token.AccessToken)
+
+	token, err = subjectB.Token()
+	require.NoError(err)
+	require.Equal("access-token-b1", token.AccessToken)
+
+	// Switch tokenSourceA to a different geography - "eu"
+	subjectC, err := NewWorkloadTokenSource(cacheFile, "workload-a", tokenSourceA, "eu")
+	require.NoError(err)
+
+	// Fetch the token once. It should create a new cache entry due to switching geography.
+	token, err = subjectC.Token()
+	require.NoError(err)
+	require.Equal("access-token-a2", token.AccessToken)
+
+	// Fetch the token of US a second time. They should be returned from cache.
+	token, err = subjectB.Token()
+	require.NoError(err)
+	require.Equal("access-token-b1", token.AccessToken)
+
+	// Verify geography is stored in the cache file
+	newCachedCredentials, err := readCache(cacheFile)
+	require.NoError(err)
+	require.Equal("access-token-a2", newCachedCredentials.Workloads["workload-a"].AccessToken)
+	require.Equal("eu", newCachedCredentials.Workloads["workload-a"].Geography)
+	// The cached token for workload-b should not be changed because the geography is the same
+	require.Equal("access-token-b1", newCachedCredentials.Workloads["workload-b"].AccessToken)
+	require.Equal("us", newCachedCredentials.Workloads["workload-b"].Geography)
 }

--- a/auth/tokencache/workload_test.go
+++ b/auth/tokencache/workload_test.go
@@ -29,7 +29,7 @@ func TestCachingTokenSource_Workloads(t *testing.T) {
 	tokenSourceA := NewTestTokenSource("a")
 	tokenSourceB := NewTestTokenSource("b")
 
-	// Create the caching token sources for service principals
+	// Create the caching token sources for workload identity
 	subjectA, err := NewWorkloadTokenSource(
 		cacheFile,
 		"workload-a",
@@ -137,7 +137,7 @@ func TestCachingTokenSource_Workloads_CompatibleWithNoGeography(t *testing.T) {
 	tokenSourceA := NewTestTokenSource("a")
 	tokenSourceB := NewTestTokenSource("b")
 
-	// Create the caching token sources for service principals
+	// Create the caching token sources for workload identity
 	subjectA, err := NewWorkloadTokenSource(
 		cacheFile,
 		"workload-a",

--- a/config/tokensource.go
+++ b/config/tokensource.go
@@ -67,11 +67,15 @@ func (c *hcpConfig) setTokenSource() error {
 			return err
 		}
 	case sourceTypeWorkload:
-		c.tokenSource = tokencache.NewWorkloadTokenSource(
+		c.tokenSource, err = tokencache.NewWorkloadTokenSource(
 			cacheFile,
 			sourceIdentifier,
 			tokenSource,
+			string(c.geography),
 		)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Remember to include an entry in the .changelog directory for this PR! More info can be found in the README. -->

### :hammer_and_wrench: Description

This PR adds geography information to the cached credential file for `workload identity` auth method. 

- Unit test for backward compability - `TestCachingTokenSource_Workload_CompatibleWithNoGeography`
- Unit test for switching geographies - `TestCachingTokenSource_Workload_SwitchGeography`

Follow-up to service principal PR https://github.com/hashicorp/hcp-sdk-go/pull/297 and login PR https://github.com/hashicorp/hcp-sdk-go/pull/296

### :link: External Links

<!-- Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section. -->

### :+1: Definition of Done

<!-- Use these as guides or delete them and add your own. -->

- [ ] <service> SDK added
- [ ] <service> SDK updated
- [ ] Tests added?
- [ ] Docs updated?

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've worked with GRC to document the impact of any changes to security controls.

  Examples of changes to controls include access controls, encryption, logging, etc.

- [ ] If applicable, I've worked with GRC to ensure compliance due to a significant change to the in-scope PCI environment.

  Examples include changes to operating systems, ports, protocols, services, cryptography-related components, PII processing code, etc.